### PR TITLE
Initial swerve + vision import and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ out/
 networktables.json
 simgui.json
 *-window.json
+simgui-ds.json
 
 # Simulation data log directory
 logs/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
       }
     },
   ],
-  "java.test.defaultConfig": "WPIlibUnitTests"
+  "java.test.defaultConfig": "WPIlibUnitTests",
+  "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
     },
   ],
   "java.test.defaultConfig": "WPIlibUnitTests",
-  "java.compile.nullAnalysis.mode": "automatic"
+  "java.compile.nullAnalysis.mode": "automatic",
+  "java.debug.settings.onBuildFailureProceed": true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ createVersionFile.dependsOn(eventDeploy)
 // Spotless formatting
 project.compileJava.dependsOn(spotlessApply)
 spotless {
+    enforceCheck false
     java {
         target fileTree(".") {
             include "**/*.java"

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ dependencies {
 
     def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
     annotationProcessor "org.littletonrobotics.akit:akit-autolog:$akitJson.version"
+
+    implementation("com.google.guava:guava:33.0.0-jre")
 }
 
 test {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -56,7 +56,7 @@ public class Robot extends LoggedRobot {
     }
   }
 
-  public static final RobotType ROBOT_TYPE = RobotType.SIM;
+  public static final RobotType ROBOT_TYPE = Robot.isReal() ? RobotType.REAL : RobotType.SIM;
   // For replay to work properly this should match the hardware used in the log
   public static final RobotHardware ROBOT_HARDWARE = RobotHardware.BANSHEE;
 
@@ -163,6 +163,8 @@ public class Robot extends LoggedRobot {
     SignalLogger.setPath("/media/sda1/");
 
     // Default Commands
+
+    driver.setDefaultCommand(driver.rumbleCmd(0.0, 0.0));
 
     swerve.setDefaultCommand(
         swerve.driveTeleop(

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,6 +6,7 @@ package frc.robot;
 
 import com.ctre.phoenix6.SignalLogger;
 import edu.wpi.first.hal.simulation.RoboRioDataJNI;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.PowerDistribution;
@@ -165,7 +166,19 @@ public class Robot extends LoggedRobot {
 
     swerve.setDefaultCommand(
         swerve.driveTeleop(
-            () -> new ChassisSpeeds(driver.getLeftY(), driver.getLeftX(), driver.getRightX())));
+            () ->
+                new ChassisSpeeds(
+                    modifyJoystick(driver.getLeftY())
+                        * ROBOT_HARDWARE.swerveConstants.getMaxLinearSpeed(),
+                    modifyJoystick(driver.getLeftX())
+                        * ROBOT_HARDWARE.swerveConstants.getMaxLinearSpeed(),
+                    modifyJoystick(driver.getRightX())
+                        * ROBOT_HARDWARE.swerveConstants.getMaxAngularSpeed())));
+  }
+
+  /** Scales a joystick value for teleop driving */
+  private static double modifyJoystick(double val) {
+    return MathUtil.applyDeadband(Math.abs(Math.pow(val, 2)) * Math.signum(val), 0.02);
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,14 +4,183 @@
 
 package frc.robot;
 
+import com.ctre.phoenix6.SignalLogger;
+import edu.wpi.first.hal.simulation.RoboRioDataJNI;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.subsystems.swerve.BansheeSwerveConstants;
+import frc.robot.subsystems.swerve.GyroIO;
+import frc.robot.subsystems.swerve.GyroIOPigeon2;
+import frc.robot.subsystems.swerve.ModuleIO;
+import frc.robot.subsystems.swerve.ModuleIOReal;
+import frc.robot.subsystems.swerve.ModuleIOSim;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread;
+import frc.robot.subsystems.swerve.SwerveConstants;
+import frc.robot.subsystems.swerve.SwerveSubsystem;
+import frc.robot.subsystems.vision.VisionIO;
+import frc.robot.subsystems.vision.VisionIOReal;
+import frc.robot.subsystems.vision.VisionIOSim;
+import frc.robot.utils.Tracer;
+import java.util.HashMap;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+import org.littletonrobotics.junction.LogFileUtil;
 import org.littletonrobotics.junction.LoggedRobot;
+import org.littletonrobotics.junction.Logger;
+import org.littletonrobotics.junction.networktables.NT4Publisher;
+import org.littletonrobotics.junction.wpilog.WPILOGReader;
+import org.littletonrobotics.junction.wpilog.WPILOGWriter;
 
 public class Robot extends LoggedRobot {
-  private Command m_autonomousCommand;
+  public enum RobotType {
+    REAL,
+    SIM,
+    REPLAY
+  }
 
-  public Robot() {}
+  public enum RobotHardware {
+    BANSHEE(new BansheeSwerveConstants()),
+    ALPHA(null), // TODO Add swerve constants as appropriate
+    COMP(null); // TODO Add swerve constants as appropriate
+
+    public final SwerveConstants swerveConstants;
+
+    private RobotHardware(SwerveConstants swerveConstants) {
+      this.swerveConstants = swerveConstants;
+    }
+  }
+
+  public static final RobotType ROBOT_TYPE = RobotType.SIM;
+  // For replay to work properly this should match the hardware used in the log
+  public static final RobotHardware ROBOT_HARDWARE = RobotHardware.BANSHEE;
+  private final SwerveSubsystem swerve =
+      new SwerveSubsystem(
+          ROBOT_HARDWARE.swerveConstants,
+          ROBOT_TYPE == RobotType.REAL
+              ? new GyroIOPigeon2(ROBOT_HARDWARE.swerveConstants.getGyroID())
+              : new GyroIO() {
+                // Blank impl in sim.
+                @Override
+                public void updateInputs(GyroIOInputs inputs) {}
+
+                @Override
+                public void setYaw(Rotation2d yaw) {}
+              },
+          Stream.of(ROBOT_HARDWARE.swerveConstants.getVisionConstants())
+              .map(
+                  (constants) ->
+                      ROBOT_TYPE == RobotType.REAL
+                          ? new VisionIOReal(constants)
+                          : new VisionIOSim(constants))
+              .toArray(VisionIO[]::new),
+          ROBOT_TYPE == RobotType.REAL
+              ? new ModuleIO[] {
+                new ModuleIOReal(
+                    ROBOT_HARDWARE.swerveConstants.getFrontLeftModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOReal(
+                    ROBOT_HARDWARE.swerveConstants.getFrontRightModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOReal(
+                    ROBOT_HARDWARE.swerveConstants.getBackLeftModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOReal(
+                    ROBOT_HARDWARE.swerveConstants.getBackRightModule(),
+                    ROBOT_HARDWARE.swerveConstants)
+              }
+              : new ModuleIO[] {
+                new ModuleIOSim(
+                    ROBOT_HARDWARE.swerveConstants.getFrontLeftModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOSim(
+                    ROBOT_HARDWARE.swerveConstants.getFrontRightModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOSim(
+                    ROBOT_HARDWARE.swerveConstants.getBackLeftModule(),
+                    ROBOT_HARDWARE.swerveConstants),
+                new ModuleIOSim(
+                    ROBOT_HARDWARE.swerveConstants.getBackRightModule(),
+                    ROBOT_HARDWARE.swerveConstants)
+              },
+          PhoenixOdometryThread.getInstance());
+
+  public Robot() {
+    SignalLogger.enableAutoLogging(false);
+    RoboRioDataJNI.setBrownoutVoltage(6.0);
+    // Metadata about the current code running on the robot
+    Logger.recordMetadata("Codebase", "Comp2025");
+    Logger.recordMetadata("RuntimeType", getRuntimeType().toString());
+    Logger.recordMetadata("Robot Mode", ROBOT_TYPE.toString());
+    Logger.recordMetadata("Robot Hardware", ROBOT_HARDWARE.toString());
+    Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+    Logger.recordMetadata("GitDate", BuildConstants.GIT_DATE);
+    Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+    switch (BuildConstants.DIRTY) {
+      case 0:
+        Logger.recordMetadata("GitDirty", "All changes committed");
+        break;
+      case 1:
+        Logger.recordMetadata("GitDirty", "Uncomitted changes");
+        break;
+      default:
+        Logger.recordMetadata("GitDirty", "Unknown");
+        break;
+    }
+    initializeTracerLogging();
+
+    switch (ROBOT_TYPE) {
+      case REAL:
+        Logger.addDataReceiver(new WPILOGWriter("/U")); // Log to a USB stick
+        Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+        new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
+        break;
+      case REPLAY:
+        setUseTiming(false); // Run as fast as possible
+        String logPath =
+            LogFileUtil
+                .findReplayLog(); // Pull the replay log from AdvantageScope (or prompt the user)
+        Logger.setReplaySource(new WPILOGReader(logPath)); // Read replay log
+        Logger.addDataReceiver(
+            new WPILOGWriter(
+                LogFileUtil.addPathSuffix(logPath, "_sim"))); // Save outputs to a new log
+        break;
+      case SIM:
+        Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+        break;
+    }
+
+    Logger.start(); // Start logging! No more data receivers, replay sources, or metadata values may
+    // be added.
+    SignalLogger.setPath("/media/sda1/");
+  }
+
+  @Override
+  public void loopFunc() {
+    Tracer.trace("Robot/LoopFunc", super::loopFunc);
+  }
+
+  private void initializeTracerLogging() {
+    HashMap<String, Integer> commandCounts = new HashMap<>();
+    final BiConsumer<Command, Boolean> logCommandFunction =
+        (Command command, Boolean active) -> {
+          String name = command.getName();
+          int count = commandCounts.getOrDefault(name, 0) + (active ? 1 : -1);
+          commandCounts.put(name, count);
+          Logger.recordOutput(
+              "Commands/CommandsUnique/" + name + "_" + Integer.toHexString(command.hashCode()),
+              active.booleanValue());
+          Logger.recordOutput("Commands/CommandsAll/" + name, count > 0);
+        };
+
+    var scheduler = CommandScheduler.getInstance();
+
+    scheduler.onCommandInitialize(c -> logCommandFunction.accept(c, true));
+    scheduler.onCommandFinish(c -> logCommandFunction.accept(c, false));
+    scheduler.onCommandInterrupt(c -> logCommandFunction.accept(c, false));
+  }
 
   @Override
   public void robotPeriodic() {
@@ -28,11 +197,7 @@ public class Robot extends LoggedRobot {
   public void disabledExit() {}
 
   @Override
-  public void autonomousInit() {
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
-    }
-  }
+  public void autonomousInit() {}
 
   @Override
   public void autonomousPeriodic() {}
@@ -41,11 +206,7 @@ public class Robot extends LoggedRobot {
   public void autonomousExit() {}
 
   @Override
-  public void teleopInit() {
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.cancel();
-    }
-  }
+  public void teleopInit() {}
 
   @Override
   public void teleopPeriodic() {}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,13 +5,12 @@
 package frc.robot;
 
 import com.ctre.phoenix6.SignalLogger;
-import edu.wpi.first.hal.simulation.RoboRioDataJNI;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.PowerDistribution;
-import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.subsystems.swerve.BansheeSwerveConstants;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import com.ctre.phoenix6.SignalLogger;
 import edu.wpi.first.hal.simulation.RoboRioDataJNI;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -23,6 +24,7 @@ import frc.robot.subsystems.swerve.SwerveSubsystem;
 import frc.robot.subsystems.vision.VisionIO;
 import frc.robot.subsystems.vision.VisionIOReal;
 import frc.robot.subsystems.vision.VisionIOSim;
+import frc.robot.utils.CommandXboxControllerSubsystem;
 import frc.robot.utils.Tracer;
 import java.util.HashMap;
 import java.util.function.BiConsumer;
@@ -56,6 +58,9 @@ public class Robot extends LoggedRobot {
   public static final RobotType ROBOT_TYPE = RobotType.SIM;
   // For replay to work properly this should match the hardware used in the log
   public static final RobotHardware ROBOT_HARDWARE = RobotHardware.BANSHEE;
+
+  private final CommandXboxControllerSubsystem driver = new CommandXboxControllerSubsystem(0);
+
   private final SwerveSubsystem swerve =
       new SwerveSubsystem(
           ROBOT_HARDWARE.swerveConstants,
@@ -155,6 +160,12 @@ public class Robot extends LoggedRobot {
     Logger.start(); // Start logging! No more data receivers, replay sources, or metadata values may
     // be added.
     SignalLogger.setPath("/media/sda1/");
+
+    // Default Commands
+
+    swerve.setDefaultCommand(
+        swerve.driveTeleop(
+            () -> new ChassisSpeeds(driver.getLeftY(), driver.getLeftX(), driver.getRightX())));
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -115,7 +116,7 @@ public class Robot extends LoggedRobot {
 
   public Robot() {
     SignalLogger.enableAutoLogging(false);
-    RoboRioDataJNI.setBrownoutVoltage(6.0);
+    RobotController.setBrownoutVoltage(6.0);
     // Metadata about the current code running on the robot
     Logger.recordMetadata("Codebase", "Comp2025");
     Logger.recordMetadata("RuntimeType", getRuntimeType().toString());

--- a/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
@@ -26,7 +26,26 @@ import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 import java.io.File;
 
-public class BansheeSwerveConstants implements SwerveConstants {
+public class BansheeSwerveConstants extends SwerveConstants {
+  private AprilTagFieldLayout fieldTags;
+  private static Alert tagLoadFailureAlert = new Alert("Failed to load custom tag map", AlertType.kWarning);
+
+  public BansheeSwerveConstants() {
+    super();
+    // TODO: update to 2025 field
+    try {
+      fieldTags =
+          new AprilTagFieldLayout(
+              Filesystem.getDeployDirectory()
+                  .toPath()
+                  .resolve("vision" + File.separator + "2024-crescendo.json"));
+      System.out.println("Successfully loaded tag map");
+    } catch (Exception e) {
+      System.err.println("Failed to load custom tag map");
+      tagLoadFailureAlert.set(true);
+      fieldTags = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+    }
+  }
 
   @Override
   public double getMaxLinearSpeed() {
@@ -87,20 +106,6 @@ public class BansheeSwerveConstants implements SwerveConstants {
   @SuppressWarnings("resource")
   @Override
   public AprilTagFieldLayout getFieldTagLayout() {
-    // TODO: update to 2025 field
-    AprilTagFieldLayout fieldTags;
-    try {
-      fieldTags =
-          new AprilTagFieldLayout(
-              Filesystem.getDeployDirectory()
-                  .toPath()
-                  .resolve("vision" + File.separator + "2024-crescendo.json"));
-      System.out.println("Successfully loaded tag map");
-    } catch (Exception e) {
-      System.err.println("Failed to load custom tag map");
-      new Alert("Failed to load custom tag map", AlertType.kWarning).set(true);
-      fieldTags = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
-    }
     return fieldTags;
   }
 

--- a/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
@@ -1,0 +1,264 @@
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
+import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.ctre.phoenix6.signals.SensorDirectionValue;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N8;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
+import edu.wpi.first.wpilibj.Filesystem;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+import java.io.File;
+
+public class BansheeSwerveConstants implements SwerveConstants {
+
+  @Override
+  public double getMaxLinearSpeed() {
+    return Units.feetToMeters(16.0);
+  }
+
+  @Override
+  public double getMaxLinearAcceleration() {
+    return 8.0;
+  }
+
+  @Override
+  public double getTrackWidthX() {
+    return Units.inchesToMeters(21.75);
+  }
+
+  @Override
+  public double getTrackWidthY() {
+    return Units.inchesToMeters(21.25);
+  }
+
+  @Override
+  public int getGyroID() {
+    return 0;
+  }
+
+  @Override
+  public double getHeadingVelocityKP() {
+    return 4.0;
+  }
+
+  @Override
+  public double getHeadingVoltageKP() {
+    return 4.0;
+  }
+
+  @Override
+  public ModuleConstants getFrontLeftModule() {
+    return new ModuleConstants(0, "Front Left", 0, 1, 0, Rotation2d.fromRotations(0.377930));
+  }
+
+  @Override
+  public ModuleConstants getFrontRightModule() {
+    return new ModuleConstants(1, "Front Right", 2, 3, 1, Rotation2d.fromRotations(-0.071289));
+  }
+
+  @Override
+  public ModuleConstants getBackLeftModule() {
+    return new ModuleConstants(2, "Back Left", 4, 5, 2, Rotation2d.fromRotations(0.550781));
+  }
+
+  @Override
+  public ModuleConstants getBackRightModule() {
+    return new ModuleConstants(3, "Back Right", 6, 7, 3, Rotation2d.fromRotations(-0.481689));
+  }
+
+  // Need this annotation so the alert doesn't get mad
+  @SuppressWarnings("resource")
+  @Override
+  public AprilTagFieldLayout getFieldTagLayout() {
+    // TODO: update to 2025 field
+    AprilTagFieldLayout fieldTags;
+    try {
+      fieldTags =
+          new AprilTagFieldLayout(
+              Filesystem.getDeployDirectory()
+                  .toPath()
+                  .resolve("vision" + File.separator + "2024-crescendo.json"));
+      System.out.println("Successfully loaded tag map");
+    } catch (Exception e) {
+      System.err.println("Failed to load custom tag map");
+      new Alert("Failed to load custom tag map", AlertType.kWarning).set(true);
+      fieldTags = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+    }
+    return fieldTags;
+  }
+
+  @Override
+  public VisionConstants[] getVisionConstants() {
+    final Matrix<N3, N3> LEFT_CAMERA_MATRIX =
+        MatBuilder.fill(
+            Nat.N3(),
+            Nat.N3(),
+            915.2126592056358,
+            0.0,
+            841.560216921862,
+            0.0,
+            913.9556728013187,
+            648.2330358379004,
+            0.0,
+            0.0,
+            1.0);
+    final Matrix<N8, N1> LEFT_DIST_COEFFS =
+        MatBuilder.fill(
+            Nat.N8(),
+            Nat.N1(),
+            0.0576413369828492,
+            -0.07356597379196807,
+            -6.669129885790735E-4,
+            6.491281122640802E-4,
+            0.03731824873787814,
+            0,
+            0,
+            0);
+    final Matrix<N3, N3> RIGHT_CAMERA_MATRIX =
+        MatBuilder.fill(
+            Nat.N3(),
+            Nat.N3(),
+            902.0832829888818,
+            0.0,
+            611.9702186077134,
+            0.0,
+            902.2731968281233,
+            400.755534902121,
+            0.0,
+            0.0,
+            1.0);
+    final Matrix<N8, N1> RIGHT_DIST_COEFFS =
+        MatBuilder.fill(
+            Nat.N8(),
+            Nat.N1(),
+            0.05398335403070431,
+            -0.07589158973947994,
+            -0.003081304772847505,
+            -0.0010797674400397023,
+            0.015185486932866137,
+            0,
+            0,
+            0);
+    final VisionConstants leftCamConstants =
+        new VisionConstants(
+            "Left_Camera",
+            new Transform3d(
+                new Translation3d(
+                    Units.inchesToMeters(-10.386),
+                    Units.inchesToMeters(10.380),
+                    Units.inchesToMeters(7.381)),
+                new Rotation3d(
+                    Units.degreesToRadians(0.0),
+                    Units.degreesToRadians(-28.125),
+                    Units.degreesToRadians(120))),
+            LEFT_CAMERA_MATRIX,
+            LEFT_DIST_COEFFS);
+    final VisionConstants rightCamConstants =
+        new VisionConstants(
+            "Right_Camera",
+            new Transform3d(
+                new Translation3d(
+                    Units.inchesToMeters(-10.597),
+                    Units.inchesToMeters(-10.143),
+                    Units.inchesToMeters(7.384)),
+                new Rotation3d(0, Units.degreesToRadians(-28.125), Units.degreesToRadians(210))),
+            RIGHT_CAMERA_MATRIX,
+            RIGHT_DIST_COEFFS);
+    return new VisionConstants[] {leftCamConstants, rightCamConstants};
+  }
+
+  @Override
+  public double getDriveGearRatio() {
+    return (50.0 / 14.0) * (16.0 / 28.0) * (45.0 / 15.0);
+  }
+
+  @Override
+  public TalonFXConfiguration getDriveConfig() {
+    TalonFXConfiguration driveConfig = new TalonFXConfiguration();
+    // Current limits
+    driveConfig.CurrentLimits.SupplyCurrentLimit = 60.0;
+    driveConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
+    // driveConfig.CurrentLimits.SupplyCurrentThreshold = 30.0;
+    // driveConfig.CurrentLimits.SupplyTimeThreshold = 0.5;
+    driveConfig.CurrentLimits.StatorCurrentLimit = 120.0;
+    driveConfig.CurrentLimits.StatorCurrentLimitEnable = true;
+    // Inverts
+    driveConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
+    driveConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    // Sensor
+    // Meters per second
+    driveConfig.Feedback.SensorToMechanismRatio = getDriveRotorToMeters();
+
+    // Current control gains
+    driveConfig.Slot0.kV = 0.0;
+    // kT (stall torque / stall current) converted to linear wheel frame
+    driveConfig.Slot0.kA = (9.37 / 483.0) / getDriveRotorToMeters(); // 3.07135116146;
+    driveConfig.Slot0.kS = 14.0;
+    driveConfig.Slot0.kP = 100.0;
+    driveConfig.Slot0.kD = 1.0;
+
+    driveConfig.TorqueCurrent.TorqueNeutralDeadband = 10.0;
+
+    driveConfig.MotionMagic.MotionMagicCruiseVelocity = getMaxLinearSpeed();
+    driveConfig.MotionMagic.MotionMagicAcceleration = getMaxLinearAcceleration();
+    return driveConfig;
+  }
+
+  @Override
+  public TalonFXConfiguration getTurnConfig(int cancoderID) {
+    var turnConfig = new TalonFXConfiguration();
+    // Current limits
+    turnConfig.CurrentLimits.StatorCurrentLimit = 40.0;
+    turnConfig.CurrentLimits.StatorCurrentLimitEnable = true;
+    // Inverts
+    turnConfig.MotorOutput.Inverted =
+        getTurnMotorInverted()
+            ? InvertedValue.Clockwise_Positive
+            : InvertedValue.CounterClockwise_Positive;
+    turnConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    // Fused Cancoder
+    turnConfig.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.FusedCANcoder;
+    turnConfig.Feedback.FeedbackRemoteSensorID = cancoderID;
+    turnConfig.Feedback.RotorToSensorRatio = getTurnGearRatio();
+    turnConfig.Feedback.SensorToMechanismRatio = 1.0;
+    turnConfig.Feedback.FeedbackRotorOffset = 0.0;
+    // Controls Gains
+    turnConfig.Slot0.kV = 2.7935;
+    turnConfig.Slot0.kA = 0.031543;
+    turnConfig.Slot0.kS = 0.28;
+    turnConfig.Slot0.kP = 400.0;
+    turnConfig.Slot0.kD = 0.68275;
+    turnConfig.MotionMagic.MotionMagicCruiseVelocity = 5500 / getTurnGearRatio();
+    turnConfig.MotionMagic.MotionMagicAcceleration = (5500 * 0.1) / getTurnGearRatio();
+    turnConfig.ClosedLoopGeneral.ContinuousWrap = true;
+    return turnConfig;
+  }
+
+  @Override
+  public CANcoderConfiguration getCancoderConfig(Rotation2d cancoderOffset) {
+    var cancoderConfig = new CANcoderConfiguration();
+    cancoderConfig.MagnetSensor.MagnetOffset = cancoderOffset.getRotations();
+    cancoderConfig.MagnetSensor.SensorDirection =
+        getTurnMotorInverted()
+            ? SensorDirectionValue.CounterClockwise_Positive
+            : SensorDirectionValue.Clockwise_Positive;
+    return cancoderConfig;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/BansheeSwerveConstants.java
@@ -28,7 +28,8 @@ import java.io.File;
 
 public class BansheeSwerveConstants extends SwerveConstants {
   private AprilTagFieldLayout fieldTags;
-  private static Alert tagLoadFailureAlert = new Alert("Failed to load custom tag map", AlertType.kWarning);
+  private static Alert tagLoadFailureAlert =
+      new Alert("Failed to load custom tag map", AlertType.kWarning);
 
   public BansheeSwerveConstants() {
     super();

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIO.java
@@ -1,0 +1,30 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import org.littletonrobotics.junction.AutoLog;
+
+public interface GyroIO {
+  @AutoLog
+  public static class GyroIOInputs {
+    public boolean connected = false;
+    public Rotation2d yawPosition = new Rotation2d();
+    public double yawVelocityRadPerSec = 0.0;
+  }
+
+  public void updateInputs(final GyroIOInputs inputs);
+
+  public void setYaw(final Rotation2d yaw);
+}

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIO.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -34,7 +34,7 @@ public class GyroIOPigeon2 implements GyroIO {
   private final StatusSignal<AngularVelocity> yawVelocity;
 
   public GyroIOPigeon2(int id) {
-    pigeon = new Pigeon2(id, "canivore");
+    pigeon = new Pigeon2(id, "*");
     yaw = pigeon.getYaw();
     yawVelocity = pigeon.getAngularVelocityZWorld();
     var config = new Pigeon2Configuration();

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -29,15 +29,18 @@ import java.util.Optional;
 
 /** IO implementation for Pigeon2 */
 public class GyroIOPigeon2 implements GyroIO {
-  private final Pigeon2 pigeon = new Pigeon2(SwerveSubsystem.PIGEON_ID, "canivore");
-  private final StatusSignal<Angle> yaw = pigeon.getYaw();
-  private final StatusSignal<AngularVelocity> yawVelocity = pigeon.getAngularVelocityZWorld();
+  private final Pigeon2 pigeon;
+  private final StatusSignal<Angle> yaw;
+  private final StatusSignal<AngularVelocity> yawVelocity;
 
-  public GyroIOPigeon2() {
+  public GyroIOPigeon2(int id) {
+    pigeon = new Pigeon2(id, "canivore");
+    yaw = pigeon.getYaw();
+    yawVelocity = pigeon.getAngularVelocityZWorld();
     var config = new Pigeon2Configuration();
     pigeon.getConfigurator().apply(config);
     pigeon.getConfigurator().setYaw(0.0);
-    yaw.setUpdateFrequency(Module.ODOMETRY_FREQUENCY_HZ);
+    yaw.setUpdateFrequency(PhoenixOdometryThread.ODOMETRY_FREQUENCY_HZ);
     yawVelocity.setUpdateFrequency(100.0);
     pigeon.optimizeBusUtilization();
     PhoenixOdometryThread.getInstance()

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -1,0 +1,61 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.StatusCode;
+import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.Pigeon2Configuration;
+import com.ctre.phoenix6.hardware.Pigeon2;
+import com.google.common.collect.ImmutableSet;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalType;
+
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+
+import java.util.Optional;
+
+/** IO implementation for Pigeon2 */
+public class GyroIOPigeon2 implements GyroIO {
+  private final Pigeon2 pigeon = new Pigeon2(SwerveSubsystem.PIGEON_ID, "canivore");
+  private final StatusSignal<Angle> yaw = pigeon.getYaw();
+  private final StatusSignal<AngularVelocity> yawVelocity = pigeon.getAngularVelocityZWorld();
+
+  public GyroIOPigeon2() {
+    var config = new Pigeon2Configuration();
+    pigeon.getConfigurator().apply(config);
+    pigeon.getConfigurator().setYaw(0.0);
+    yaw.setUpdateFrequency(Module.ODOMETRY_FREQUENCY_HZ);
+    yawVelocity.setUpdateFrequency(100.0);
+    pigeon.optimizeBusUtilization();
+    PhoenixOdometryThread.getInstance()
+        .registerSignals(
+            new Registration(pigeon, Optional.empty(), SignalType.GYRO, ImmutableSet.of(yaw)));
+  }
+
+  @Override
+  public void updateInputs(GyroIOInputs inputs) {
+    inputs.connected = BaseStatusSignal.refreshAll(yaw, yawVelocity).equals(StatusCode.OK);
+    inputs.yawPosition = new Rotation2d(yaw.getValue());
+    inputs.yawVelocityRadPerSec = yawVelocity.getValue().in(RadiansPerSecond);
+  }
+
+  @Override
+  public void setYaw(Rotation2d yaw) {
+    pigeon.setYaw(yaw.getDegrees());
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -13,6 +13,8 @@
 
 package frc.robot.subsystems.swerve;
 
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusCode;
 import com.ctre.phoenix6.StatusSignal;
@@ -24,9 +26,6 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
 import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalType;
-
-import static edu.wpi.first.units.Units.RadiansPerSecond;
-
 import java.util.Optional;
 
 /** IO implementation for Pigeon2 */

--- a/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
+++ b/src/main/java/frc/robot/subsystems/swerve/GyroIOPigeon2.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -1,0 +1,179 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import edu.wpi.first.hal.simulation.RoboRioDataJNI;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Timer;
+import org.littletonrobotics.junction.Logger;
+
+public class Module {
+  // Represents per-module constants
+  public record ModuleConstants(
+      int id, String prefix, int driveID, int turnID, int cancoderID, Rotation2d cancoderOffset) {}
+
+  // Global constants
+  public static final double WHEEL_RADIUS = Units.inchesToMeters(2.0);
+  public static final double ODOMETRY_FREQUENCY_HZ = 250.0;
+
+  // Gear ratios for SDS MK4i L3.5, adjust as necessary
+  // These numbers are taken from SDS's website
+  // They are the gear tooth counts for each stage of the modules' gearboxes
+  public static final double DRIVE_GEAR_RATIO = (50.0 / 14.0) * (16.0 / 28.0) * (45.0 / 15.0);
+  public static final double DRIVE_ROTOR_TO_METERS =
+      (Module.DRIVE_GEAR_RATIO) * (1.0 / (Module.WHEEL_RADIUS * 2 * Math.PI));
+  public static final double TURN_GEAR_RATIO = 150.0 / 7.0;
+
+  public static final double TURN_STATOR_CURRENT_LIMIT = 40.0;
+
+  private final ModuleIO io;
+  private final ModuleIOInputsAutoLogged inputs = new ModuleIOInputsAutoLogged();
+
+  private SwerveModuleState lastSetpoint = new SwerveModuleState();
+  private double lastTime = Timer.getFPGATimestamp();
+
+  public Module(final ModuleIO io) {
+    this.io = io;
+  }
+
+  /** Update inputs without running the rest of the periodic logic. */
+  public void updateInputs() {
+    io.updateInputs(inputs);
+  }
+
+  public void periodic() {
+    Logger.processInputs(String.format("Swerve/%s Module", inputs.prefix), inputs);
+    Logger.recordOutput(
+        String.format("Swerve/%s Module/Voltage Available", inputs.prefix),
+        Math.abs(inputs.driveAppliedVolts - RoboRioDataJNI.getVInVoltage()));
+  }
+
+  /** Runs the module closed loop with the specified setpoint state. Returns the optimized state. */
+  public SwerveModuleState runSetpoint(SwerveModuleState state) {
+    return runSetpoint(state, 0.0, 0.0);
+  }
+
+  /** Runs the module closed loop with the specified setpoint state. Returns the optimized state. */
+  public SwerveModuleState runSetpoint(
+      SwerveModuleState state, double forceXNewtons, double forceYNewtons) {
+    // Optimize state based on current angle
+    final var optimizedState = SwerveModuleState.optimize(state, getAngle());
+    // force on the motor is the total force vector projected onto the velocity vector
+    // to project a onto b take ||a||*cos(theta) where theta is the angle between the two vectors
+    // We want the magnitude of the projection, so we can ignore the direction of this later
+    final var theta = Math.atan2(forceYNewtons, forceXNewtons) - inputs.turnPosition.getRadians();
+    final double forceNewtons = Math.hypot(forceXNewtons, forceYNewtons) * Math.cos(theta);
+
+    io.setTurnSetpoint(optimizedState.angle);
+    io.setDriveSetpoint(
+        optimizedState.speedMetersPerSecond
+            * Math.cos(optimizedState.angle.minus(inputs.turnPosition).getRadians()),
+        forceNewtons);
+    Logger.recordOutput(
+        String.format("Swerve/%s Module/Force Feedforward", inputs.prefix), forceNewtons);
+    lastSetpoint = optimizedState;
+    lastTime = Timer.getFPGATimestamp();
+    return optimizedState;
+  }
+
+  /**
+   * Runs the module open loop with the specified setpoint state, velocity in volts. Returns the
+   * optimized state.
+   */
+  public SwerveModuleState runVoltageSetpoint(SwerveModuleState state, boolean focEnabled) {
+    // Optimize state based on current angle
+    final var optimizedState = SwerveModuleState.optimize(state, getAngle());
+    Logger.recordOutput(
+        String.format("Swerve/%s Module/Voltage Target", inputs.prefix),
+        optimizedState.speedMetersPerSecond);
+
+    io.setTurnSetpoint(optimizedState.angle);
+    io.setDriveVoltage(
+        optimizedState.speedMetersPerSecond
+            * Math.cos(optimizedState.angle.minus(inputs.turnPosition).getRadians()),
+        focEnabled);
+
+    return optimizedState;
+  }
+
+  /**
+   * Runs the module open loop with the specified setpoint state, velocity in volts. Returns the
+   * optimized state.
+   */
+  public SwerveModuleState runVoltageSetpoint(SwerveModuleState state) {
+    return runVoltageSetpoint(state, true);
+  }
+
+  /** Runs the module with the specified voltage while controlling to zero degrees. */
+  public void runDriveCharacterization(double volts) {
+    // Closed loop turn control
+    io.setTurnSetpoint(Rotation2d.fromRotations(0.0));
+
+    // Open loop drive control
+    io.setDriveVoltage(volts);
+  }
+
+  /** Runs the module angle with the specified voltage while not moving the drive motor */
+  public void runSteerCharacterization(double volts) {
+    io.setTurnVoltage(volts);
+    io.setDriveVoltage(0.0);
+  }
+
+  /** Disables all outputs to motors. */
+  public void stop() {
+    io.setTurnVoltage(0.0);
+    io.setDriveVoltage(0.0);
+  }
+
+  /** Returns the current turn angle of the module at normal sampling frequency. */
+  public Rotation2d getAngle() {
+    return inputs.turnPosition;
+  }
+
+  /** Returns the current drive position of the module in meters at normal sampling frequency. */
+  public double getPositionMeters() {
+    return inputs.drivePositionMeters;
+  }
+
+  /** Returns this modules prefix ie "Back Left" */
+  public String getPrefix() {
+    return inputs.prefix;
+  }
+
+  /**
+   * Returns the current drive velocity of the module in meters per second withat normal sampling
+   * frequency.
+   */
+  public double getVelocityMetersPerSec() {
+    return inputs.driveVelocityMetersPerSec;
+  }
+
+  /** Returns the module position (turn angle and drive position) at normal sampling frequency. */
+  public SwerveModulePosition getPosition() {
+    return new SwerveModulePosition(getPositionMeters(), getAngle());
+  }
+
+  /** Returns the module state (turn angle and drive velocity) at normal sampling frequency. */
+  public SwerveModuleState getState() {
+    return new SwerveModuleState(getVelocityMetersPerSec(), getAngle());
+  }
+
+  /** Returns the drive velocity in meters/sec. */
+  public double getCharacterizationVelocity() {
+    return inputs.driveVelocityMetersPerSec;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -15,7 +15,6 @@ package frc.robot.subsystems.swerve;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.math.util.Units;
 import org.littletonrobotics.junction.Logger;
 
 /** Wrapper around ModuleIO and ModuleIOInputs to organize module-level functionality. */
@@ -23,20 +22,6 @@ public class Module {
   // Represents per-module constants
   public record ModuleConstants(
       int id, String prefix, int driveID, int turnID, int cancoderID, Rotation2d cancoderOffset) {}
-
-  // Global constants
-  public static final double WHEEL_RADIUS = Units.inchesToMeters(2.0);
-  public static final double ODOMETRY_FREQUENCY_HZ = 250.0;
-
-  // Gear ratios for SDS MK4i L3.5, adjust as necessary
-  // These numbers are taken from SDS's website
-  // They are the gear tooth counts for each stage of the modules' gearboxes
-  public static final double DRIVE_GEAR_RATIO = (50.0 / 14.0) * (16.0 / 28.0) * (45.0 / 15.0);
-  public static final double DRIVE_ROTOR_TO_METERS =
-      (Module.DRIVE_GEAR_RATIO) * (1.0 / (Module.WHEEL_RADIUS * 2 * Math.PI));
-  public static final double TURN_GEAR_RATIO = 150.0 / 7.0;
-
-  public static final double TURN_STATOR_CURRENT_LIMIT = 40.0;
 
   private final ModuleIO io;
   private final ModuleIOInputsAutoLogged inputs = new ModuleIOInputsAutoLogged();
@@ -72,8 +57,7 @@ public class Module {
 
     io.setTurnSetpoint(state.angle);
     io.setDriveSetpoint(
-        state.speedMetersPerSecond
-            * Math.cos(state.angle.minus(inputs.turnPosition).getRadians()),
+        state.speedMetersPerSecond * Math.cos(state.angle.minus(inputs.turnPosition).getRadians()),
         forceNewtons);
     Logger.recordOutput(
         String.format("Swerve/%s Module/Force Feedforward", inputs.prefix), forceNewtons);
@@ -93,8 +77,7 @@ public class Module {
 
     io.setTurnSetpoint(state.angle);
     io.setDriveVoltage(
-        state.speedMetersPerSecond
-            * Math.cos(state.angle.minus(inputs.turnPosition).getRadians()),
+        state.speedMetersPerSecond * Math.cos(state.angle.minus(inputs.turnPosition).getRadians()),
         focEnabled);
 
     return state;

--- a/src/main/java/frc/robot/subsystems/swerve/Module.java
+++ b/src/main/java/frc/robot/subsystems/swerve/Module.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
@@ -1,0 +1,61 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import org.littletonrobotics.junction.AutoLog;
+
+public interface ModuleIO {
+  @AutoLog
+  public static class ModuleIOInputs {
+    public String prefix = "";
+
+    public double drivePositionMeters = 0.0;
+    public double driveVelocityMetersPerSec = 0.0;
+    public double driveAppliedVolts = 0.0;
+    public double driveCurrentAmps = 0.0;
+    public double driveSupplyCurrentAmps = 0.0;
+
+    public Rotation2d turnAbsolutePosition = new Rotation2d();
+    public Rotation2d turnPosition = new Rotation2d();
+    public double turnVelocityRadPerSec = 0.0;
+    public double turnAppliedVolts = 0.0;
+    public double turnCurrentAmps = 0.0;
+  }
+
+  /** Updates the set of loggable inputs. */
+  public void updateInputs(final ModuleIOInputs inputs);
+
+  /** Run the drive motor at the specified voltage. */
+  public default void setDriveVoltage(final double volts) {
+    setDriveVoltage(volts, true);
+  }
+
+  /** Run the drive motor at the specified voltage. */
+  public void setDriveVoltage(final double volts, final boolean focEnabled);
+
+  /** Use onboard PIDF to run the drive motor at the specified speed */
+  public default void setDriveSetpoint(final double metersPerSecond) {
+    setDriveSetpoint(metersPerSecond, 0.0);
+  }
+
+  /** Use onboard PIDF to run the drive motor at the specified speed */
+  public void setDriveSetpoint(final double metersPerSecond, final double forceNewtons);
+
+  /** Run the turn motor at the specified voltage. */
+  public void setTurnVoltage(final double volts);
+
+  /** Use onboard PIDF to run the turn motor to the specified rotation */
+  public void setTurnSetpoint(final Rotation2d rotation);
+}

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIO.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -1,0 +1,273 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VelocityTorqueCurrentFOC;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.CANcoder;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
+import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.ctre.phoenix6.signals.SensorDirectionValue;
+import com.google.common.collect.ImmutableSet;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.util.Units;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Registration;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalType;
+import java.util.Optional;
+
+/**
+ * Module IO implementation for Talon FX drive motor controller, Talon FX turn motor controller, and
+ * CANcoder
+ *
+ * <p>NOTE: This implementation should be used as a starting point and adapted to different hardware
+ * configurations (e.g. If using an analog encoder, copy from "ModuleIOSparkMax")
+ *
+ * <p>To calibrate the absolute encoder offsets, point the modules straight (such that forward
+ * motion on the drive motor will propel the robot forward) and copy the reported values from the
+ * absolute encoders using AdvantageScope. These values are logged under
+ * "/Swerve/ModuleX/TurnAbsolutePositionRad"
+ */
+public class ModuleIOReal implements ModuleIO {
+  // Constants
+  private static final boolean IS_TURN_MOTOR_INVERTED = true;
+
+  // Constant so sim can access it
+  public static final TalonFXConfiguration DRIVE_CONFIG = new TalonFXConfiguration();
+
+  static {
+    // Current limits
+    // TODO: Do we want to limit supply current?
+    DRIVE_CONFIG.CurrentLimits.SupplyCurrentLimit = 60.0;
+    DRIVE_CONFIG.CurrentLimits.SupplyCurrentLimitEnable = true;
+    // driveConfig.CurrentLimits.SupplyCurrentThreshold = 30.0;
+    // driveConfig.CurrentLimits.SupplyTimeThreshold = 0.5;
+    DRIVE_CONFIG.CurrentLimits.StatorCurrentLimit = 120.0;
+    DRIVE_CONFIG.CurrentLimits.StatorCurrentLimitEnable = true;
+    // Inverts
+    DRIVE_CONFIG.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
+    DRIVE_CONFIG.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    // Sensor
+    // Meters per second
+    DRIVE_CONFIG.Feedback.SensorToMechanismRatio = Module.DRIVE_ROTOR_TO_METERS;
+    // Voltage Controls Gains
+    DRIVE_CONFIG.Slot0.kV = 2.381;
+    DRIVE_CONFIG.Slot0.kA = 0.65;
+    DRIVE_CONFIG.Slot0.kS = 0.04;
+    DRIVE_CONFIG.Slot0.kP = 2.0;
+    DRIVE_CONFIG.Slot0.kD = 0.2;
+
+    // Current control gains
+    DRIVE_CONFIG.Slot1.kV = 0.0;
+    DRIVE_CONFIG.Slot1.kA = (9.37 / 483.0) / Module.DRIVE_ROTOR_TO_METERS; // 3.07135116146;
+    DRIVE_CONFIG.Slot1.kS = 14.0;
+    DRIVE_CONFIG.Slot1.kP = 100.0;
+    DRIVE_CONFIG.Slot1.kD = 1.0;
+
+    DRIVE_CONFIG.TorqueCurrent.TorqueNeutralDeadband = 10.0;
+
+    DRIVE_CONFIG.MotionMagic.MotionMagicCruiseVelocity = SwerveSubsystem.MAX_LINEAR_SPEED;
+    DRIVE_CONFIG.MotionMagic.MotionMagicAcceleration = SwerveSubsystem.MAX_LINEAR_ACCELERATION;
+    // driveConfig.MotionMagic.MotionMagicJerk = SwerveSubsystem.MAX_LINEAR_ACCELERATION / 0.1;
+  }
+
+  private final ModuleConstants constants;
+
+  // Hardware
+  // Must be accessible to sim subclass
+  private final TalonFX driveTalon;
+  private final TalonFX turnTalon;
+  private final CANcoder cancoder;
+
+  // Signals
+  private final BaseStatusSignal drivePosition;
+  private final BaseStatusSignal driveVelocity;
+  private final BaseStatusSignal driveAppliedVolts;
+  private final BaseStatusSignal driveCurrent;
+  private final BaseStatusSignal driveSupplyCurrent;
+
+  private final BaseStatusSignal turnAbsolutePosition;
+  private final BaseStatusSignal turnPosition;
+  private final BaseStatusSignal turnVelocity;
+  private final BaseStatusSignal turnAppliedVolts;
+  private final BaseStatusSignal turnCurrent;
+
+  // Control modes
+  private final VoltageOut driveVoltage = new VoltageOut(0.0).withEnableFOC(true);
+  private final VoltageOut turnVoltage = new VoltageOut(0.0).withEnableFOC(true);
+  private final VelocityTorqueCurrentFOC driveControlVelocity =
+      new VelocityTorqueCurrentFOC(0.0).withSlot(1);
+  // new VelocityVoltage(0.0).withEnableFOC(true).withSlot(0);
+  private final MotionMagicVoltage turnPID = new MotionMagicVoltage(0.0).withEnableFOC(true);
+
+  private final double kAVoltsPerMeterPerSecondSquared;
+
+  public ModuleIOReal(ModuleConstants constants) {
+    this.constants = constants;
+
+    driveTalon = new TalonFX(constants.driveID(), "canivore");
+    turnTalon = new TalonFX(constants.turnID(), "canivore");
+    cancoder = new CANcoder(constants.cancoderID(), "canivore");
+
+    kAVoltsPerMeterPerSecondSquared = DRIVE_CONFIG.Slot0.kA;
+
+    driveTalon.getConfigurator().apply(DRIVE_CONFIG);
+
+    var turnConfig = new TalonFXConfiguration();
+    // Current limits
+    turnConfig.CurrentLimits.StatorCurrentLimit = Module.TURN_STATOR_CURRENT_LIMIT;
+    turnConfig.CurrentLimits.StatorCurrentLimitEnable = true;
+    // Inverts
+    turnConfig.MotorOutput.Inverted =
+        IS_TURN_MOTOR_INVERTED
+            ? InvertedValue.Clockwise_Positive
+            : InvertedValue.CounterClockwise_Positive;
+    turnConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
+    // Fused Cancoder
+    turnConfig.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.FusedCANcoder;
+    turnConfig.Feedback.FeedbackRemoteSensorID = constants.cancoderID();
+    turnConfig.Feedback.RotorToSensorRatio = Module.TURN_GEAR_RATIO;
+    turnConfig.Feedback.SensorToMechanismRatio = 1.0;
+    turnConfig.Feedback.FeedbackRotorOffset =
+        0.0; // Is this correct? Cancoder config should handle it
+    // Controls Gains
+    turnConfig.Slot0.kV = 2.7935;
+    turnConfig.Slot0.kA = 0.031543;
+    turnConfig.Slot0.kS = 0.28;
+    turnConfig.Slot0.kP = 400.0;
+    turnConfig.Slot0.kD = 0.68275;
+    turnConfig.MotionMagic.MotionMagicCruiseVelocity = 5500 / Module.TURN_GEAR_RATIO;
+    turnConfig.MotionMagic.MotionMagicAcceleration = (5500 * 0.1) / Module.TURN_GEAR_RATIO;
+    turnConfig.ClosedLoopGeneral.ContinuousWrap = true;
+
+    turnTalon.getConfigurator().apply(turnConfig);
+
+    var cancoderConfig = new CANcoderConfiguration();
+    cancoderConfig.MagnetSensor.MagnetOffset = constants.cancoderOffset().getRotations();
+    cancoderConfig.MagnetSensor.SensorDirection =
+        IS_TURN_MOTOR_INVERTED
+            ? SensorDirectionValue.CounterClockwise_Positive
+            : SensorDirectionValue.Clockwise_Positive;
+    cancoder.getConfigurator().apply(cancoderConfig);
+
+    drivePosition = driveTalon.getPosition();
+    driveVelocity = driveTalon.getVelocity();
+    driveAppliedVolts = driveTalon.getMotorVoltage();
+    driveCurrent = driveTalon.getStatorCurrent();
+    driveSupplyCurrent = driveTalon.getSupplyCurrent();
+
+    turnAbsolutePosition = cancoder.getAbsolutePosition();
+    turnPosition = turnTalon.getPosition();
+    turnVelocity = turnTalon.getVelocity();
+    turnAppliedVolts = turnTalon.getMotorVoltage();
+    turnCurrent = turnTalon.getStatorCurrent();
+
+    PhoenixOdometryThread.getInstance()
+        .registerSignals(
+            new Registration(
+                driveTalon,
+                Optional.of(constants),
+                SignalType.DRIVE,
+                ImmutableSet.of(drivePosition)),
+            new Registration(
+                turnTalon,
+                Optional.of(constants),
+                SignalType.STEER,
+                ImmutableSet.of(turnPosition)));
+
+    BaseStatusSignal.setUpdateFrequencyForAll(
+        Module.ODOMETRY_FREQUENCY_HZ, drivePosition, turnPosition);
+    BaseStatusSignal.setUpdateFrequencyForAll(
+        50.0,
+        driveVelocity,
+        driveAppliedVolts,
+        driveCurrent,
+        driveSupplyCurrent,
+        turnAbsolutePosition,
+        turnVelocity,
+        turnAppliedVolts,
+        turnCurrent);
+    driveTalon.optimizeBusUtilization();
+    turnTalon.optimizeBusUtilization();
+    cancoder.optimizeBusUtilization();
+  }
+
+  @Override
+  public void updateInputs(final ModuleIOInputs inputs) {
+    BaseStatusSignal.refreshAll(
+        drivePosition,
+        driveVelocity,
+        driveAppliedVolts,
+        driveCurrent,
+        driveSupplyCurrent,
+        turnAbsolutePosition,
+        turnPosition,
+        turnVelocity,
+        turnAppliedVolts,
+        turnCurrent);
+
+    inputs.prefix = constants.prefix();
+
+    inputs.drivePositionMeters = drivePosition.getValueAsDouble();
+    inputs.driveVelocityMetersPerSec = driveVelocity.getValueAsDouble();
+    inputs.driveAppliedVolts = driveAppliedVolts.getValueAsDouble();
+    inputs.driveCurrentAmps = driveCurrent.getValueAsDouble();
+    inputs.driveSupplyCurrentAmps = driveSupplyCurrent.getValueAsDouble();
+
+    inputs.turnAbsolutePosition = Rotation2d.fromRotations(turnAbsolutePosition.getValueAsDouble());
+    inputs.turnPosition = Rotation2d.fromRotations(turnPosition.getValueAsDouble());
+    inputs.turnVelocityRadPerSec = Units.rotationsToRadians(turnVelocity.getValueAsDouble());
+    inputs.turnAppliedVolts = turnAppliedVolts.getValueAsDouble();
+    inputs.turnCurrentAmps = turnCurrent.getValueAsDouble();
+  }
+
+  @Override
+  public void setDriveVoltage(final double volts, final boolean focEnabled) {
+    driveTalon.setControl(driveVoltage.withOutput(volts).withEnableFOC(focEnabled));
+  }
+
+  @Override
+  public void setTurnVoltage(final double volts) {
+    turnTalon.setControl(turnVoltage.withOutput(volts));
+  }
+
+  @Override
+  public void setDriveSetpoint(final double metersPerSecond, final double forceNewtons) {
+    // Doesnt actually refresh drive velocity signal, but should be cached
+    if (metersPerSecond == 0
+        && forceNewtons == 0
+        && MathUtil.isNear(0.0, driveVelocity.getValueAsDouble(), 0.1)) {
+      setDriveVoltage(0.0);
+    } else {
+      driveTalon.setControl(
+          driveControlVelocity
+              .withVelocity(metersPerSecond)
+              .withFeedForward(forceNewtons / DCMotor.getKrakenX60Foc(1).KtNMPerAmp));
+    }
+  }
+
+  @Override
+  public void setTurnSetpoint(final Rotation2d rotation) {
+    turnTalon.setControl(turnPID.withPosition(rotation.getRotations()));
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -14,7 +14,6 @@
 package frc.robot.subsystems.swerve;
 
 import com.ctre.phoenix6.BaseStatusSignal;
-import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOReal.java
@@ -71,9 +71,9 @@ public class ModuleIOReal implements ModuleIO {
   public ModuleIOReal(ModuleConstants moduleConstants, SwerveConstants swerveConstants) {
     this.constants = moduleConstants;
 
-    driveTalon = new TalonFX(moduleConstants.driveID(), "canivore");
-    turnTalon = new TalonFX(moduleConstants.turnID(), "canivore");
-    cancoder = new CANcoder(moduleConstants.cancoderID(), "canivore");
+    driveTalon = new TalonFX(moduleConstants.driveID(), "*");
+    turnTalon = new TalonFX(moduleConstants.turnID(), "*");
+    cancoder = new CANcoder(moduleConstants.cancoderID(), "*");
 
     driveTalon.getConfigurator().apply(swerveConstants.getDriveConfig());
 

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -38,6 +38,7 @@ public class ModuleIOSim implements ModuleIO {
   private final SwerveConstants swerveConstants;
 
   private static final DCMotor driveMotor = DCMotor.getKrakenX60Foc(1);
+  private static final DCMotor steerMotor = DCMotor.getKrakenX60Foc(1);
   private final TalonFX driveTalon;
   private final VoltageOut driveVoltage = new VoltageOut(0.0).withEnableFOC(true);
   private final VelocityTorqueCurrentFOC driveControlVelocity =
@@ -69,8 +70,10 @@ public class ModuleIOSim implements ModuleIO {
     turnSim = // Third param is the moment of inertia of the swerve steer
         new DCMotorSim(
             LinearSystemId.createDCMotorSystem(
-                DCMotor.getKrakenX60Foc(1), swerveConstants.getTurnGearRatio(), 0.0040),
-            DCMotor.getKrakenX60Foc(1).withReduction(swerveConstants.getTurnGearRatio()),
+                steerMotor,
+                0.0040,
+                swerveConstants.getTurnGearRatio()),
+            steerMotor,
             0,
             0);
   }

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -1,5 +1,4 @@
-// Copyright 2021-2023 FRC 6328
-// http://github.com/Mechanical-Advantage
+// Copyright 2023-2025 FRC 8033
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -63,6 +63,7 @@ public class ModuleIOSim implements ModuleIO {
             LinearSystemId.createDCMotorSystem(
                 driveMotor, 0.025, swerveConstants.getDriveGearRatio()),
             driveMotor,
+            0,
             0);
 
     turnSim = // Third param is the moment of inertia of the swerve steer
@@ -70,6 +71,7 @@ public class ModuleIOSim implements ModuleIO {
             LinearSystemId.createDCMotorSystem(
                 DCMotor.getKrakenX60Foc(1), swerveConstants.getTurnGearRatio(), 0.0040),
             DCMotor.getKrakenX60Foc(1).withReduction(swerveConstants.getTurnGearRatio()),
+            0,
             0);
   }
 

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -1,0 +1,115 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.controls.VelocityTorqueCurrentFOC;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.sim.ChassisReference;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+
+/**
+ * Physics sim implementation of module IO.
+ *
+ * <p>Uses two flywheel sims for the drive and turn motors, with the absolute position initialized
+ * to a random value. The flywheel sims are not physically accurate, but provide a decent
+ * approximation for the behavior of the module.
+ */
+public class ModuleIOSim implements ModuleIO {
+  private static final double LOOP_PERIOD_SECS = 0.02;
+
+  private final ModuleConstants constants;
+
+  private static final DCMotor driveMotor = DCMotor.getKrakenX60Foc(1);
+  private final TalonFX driveTalon;
+  private final VoltageOut driveVoltage = new VoltageOut(0.0).withEnableFOC(true);
+  private final VelocityTorqueCurrentFOC driveControlVelocity =
+      new VelocityTorqueCurrentFOC(0.0).withSlot(1);
+  private final DCMotorSim driveSim =
+      // Third param is the moment of inertia of the swerve wheel
+      // Used to approximate the robot inertia, not perfect but fine for the
+      // Fidelity of simulation we are targeting
+      new DCMotorSim(LinearSystemId.createDCMotorSystem(driveMotor, 0.025, Module.DRIVE_GEAR_RATIO), driveMotor, 0);
+  private final DCMotorSim turnSim =
+      // Third param is the moment of inertia of the swerve steer
+      new DCMotorSim(LinearSystemId.createDCMotorSystem(DCMotor.getKrakenX60Foc(1), Module.TURN_GEAR_RATIO, 0.0040), DCMotor.getKrakenX60Foc(1).withReduction(Module.TURN_GEAR_RATIO), 0);
+
+  private final Rotation2d turnAbsoluteInitPosition = new Rotation2d(Math.random() * 2.0 * Math.PI);
+  private double turnAppliedVolts = 0.0;
+
+  private final PIDController turnController = new PIDController(100.0, 0.0, 0.0);
+
+  public ModuleIOSim(final ModuleConstants constants) {
+    this.constants = constants;
+    driveTalon = new TalonFX(constants.driveID());
+    driveTalon.getConfigurator().apply(ModuleIOReal.DRIVE_CONFIG);
+  }
+
+  @Override
+  public void updateInputs(final ModuleIOInputs inputs) {
+    final var driveSimState = driveTalon.getSimState();
+    driveSimState.Orientation = ChassisReference.Clockwise_Positive;
+    // driveSimState.setSupplyVoltage(RoboRioSim.getVInVoltage());
+    driveSim.setInput(driveSimState.getMotorVoltage());
+
+    driveSim.update(LOOP_PERIOD_SECS);
+    turnSim.update(LOOP_PERIOD_SECS);
+    driveSimState.setRotorVelocity(
+        (driveSim.getAngularVelocityRPM() / 60.0) * Module.DRIVE_GEAR_RATIO);
+
+    inputs.prefix = constants.prefix();
+
+    inputs.drivePositionMeters = driveSim.getAngularPositionRad() * Module.WHEEL_RADIUS;
+    inputs.driveVelocityMetersPerSec = driveSim.getAngularVelocityRadPerSec() * Module.WHEEL_RADIUS;
+    inputs.driveAppliedVolts = driveSimState.getMotorVoltage();
+    inputs.driveCurrentAmps = Math.abs(driveSim.getCurrentDrawAmps());
+
+    inputs.turnAbsolutePosition =
+        new Rotation2d(turnSim.getAngularPositionRad()).plus(turnAbsoluteInitPosition);
+    inputs.turnPosition = new Rotation2d(turnSim.getAngularPositionRad());
+    inputs.turnVelocityRadPerSec = turnSim.getAngularVelocityRadPerSec();
+    inputs.turnAppliedVolts = turnAppliedVolts;
+    inputs.turnCurrentAmps = Math.abs(turnSim.getCurrentDrawAmps());
+  }
+
+  @Override
+  public void setDriveVoltage(final double volts, final boolean focEnabled) {
+    driveTalon.setControl(driveVoltage.withOutput(volts).withEnableFOC(focEnabled));
+  }
+
+  @Override
+  public void setTurnVoltage(final double volts) {
+    turnAppliedVolts = MathUtil.clamp(volts, -12.0, 12.0);
+    turnSim.setInputVoltage(turnAppliedVolts);
+  }
+
+  @Override
+  public void setDriveSetpoint(final double metersPerSecond, final double forceNewtons) {
+    driveTalon.setControl(
+        driveControlVelocity.withVelocity(metersPerSecond).withFeedForward(forceNewtons));
+  }
+
+  @Override
+  public void setTurnSetpoint(final Rotation2d rotation) {
+    setTurnVoltage(
+        turnController.calculate(turnSim.getAngularPositionRotations(), rotation.getRotations()));
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -20,7 +20,6 @@ import com.ctre.phoenix6.sim.ChassisReference;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.system.LinearSystem;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
@@ -47,10 +46,17 @@ public class ModuleIOSim implements ModuleIO {
       // Third param is the moment of inertia of the swerve wheel
       // Used to approximate the robot inertia, not perfect but fine for the
       // Fidelity of simulation we are targeting
-      new DCMotorSim(LinearSystemId.createDCMotorSystem(driveMotor, 0.025, Module.DRIVE_GEAR_RATIO), driveMotor, 0);
+      new DCMotorSim(
+          LinearSystemId.createDCMotorSystem(driveMotor, 0.025, Module.DRIVE_GEAR_RATIO),
+          driveMotor,
+          0);
   private final DCMotorSim turnSim =
       // Third param is the moment of inertia of the swerve steer
-      new DCMotorSim(LinearSystemId.createDCMotorSystem(DCMotor.getKrakenX60Foc(1), Module.TURN_GEAR_RATIO, 0.0040), DCMotor.getKrakenX60Foc(1).withReduction(Module.TURN_GEAR_RATIO), 0);
+      new DCMotorSim(
+          LinearSystemId.createDCMotorSystem(
+              DCMotor.getKrakenX60Foc(1), Module.TURN_GEAR_RATIO, 0.0040),
+          DCMotor.getKrakenX60Foc(1).withReduction(Module.TURN_GEAR_RATIO),
+          0);
 
   private final Rotation2d turnAbsoluteInitPosition = new Rotation2d(Math.random() * 2.0 * Math.PI);
   private double turnAppliedVolts = 0.0;

--- a/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
+++ b/src/main/java/frc/robot/subsystems/swerve/ModuleIOSim.java
@@ -70,9 +70,7 @@ public class ModuleIOSim implements ModuleIO {
     turnSim = // Third param is the moment of inertia of the swerve steer
         new DCMotorSim(
             LinearSystemId.createDCMotorSystem(
-                steerMotor,
-                0.0040,
-                swerveConstants.getTurnGearRatio()),
+                steerMotor, 0.0040, swerveConstants.getTurnGearRatio()),
             steerMotor,
             0,
             0);

--- a/src/main/java/frc/robot/subsystems/swerve/OdometryThreadIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/OdometryThreadIO.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
 
+/** Provides an interface for high frequency sampling of robot odometry. */
 public interface OdometryThreadIO {
   public static final int GYRO_MODULE_ID = -1;
 

--- a/src/main/java/frc/robot/subsystems/swerve/OdometryThreadIO.java
+++ b/src/main/java/frc/robot/subsystems/swerve/OdometryThreadIO.java
@@ -1,0 +1,80 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.swerve;
+
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalID;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalType;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.littletonrobotics.junction.LogTable;
+import org.littletonrobotics.junction.inputs.LoggableInputs;
+
+public interface OdometryThreadIO {
+  public static final int GYRO_MODULE_ID = -1;
+
+  public class OdometryThreadIOInputs implements LoggableInputs {
+    List<Samples> sampledStates = List.of();
+
+    @Override
+    public void toLog(LogTable table) {
+      var timestamps = sampledStates.stream().mapToDouble(Samples::timestamp).toArray();
+      Set<Integer> modIds = new HashSet();
+      for (int i = 0; i < sampledStates.size(); i++) {
+        var sample = sampledStates.get(i);
+        for (var signal : sample.values().entrySet()) {
+          table.put(
+              "Data/" + i + " " + signal.getKey().type().toString() + " " + signal.getKey().modID(),
+              signal.getValue());
+          modIds.add(signal.getKey().modID());
+        }
+      }
+      // Remove Gyro/placeholder
+      modIds.remove(-1);
+      table.put("Module IDs", modIds.stream().mapToInt(Integer::intValue).toArray());
+      table.put("Timestamps", timestamps);
+    }
+
+    @Override
+    public void fromLog(LogTable table) {
+      sampledStates = List.of();
+      var modIds = table.get("Module IDs").getIntegerArray();
+      var timestamps = table.get("Timestamps").getDoubleArray();
+      for (int i = 0; i < sampledStates.size(); i++) {
+        var timestamp = timestamps[i];
+        try {
+          Map<SignalID, Double> values = new HashMap();
+          for (var id : modIds) {
+            values.put(
+                new SignalID(SignalType.DRIVE, (int) id),
+                table.get("Data/" + i + " " + SignalType.DRIVE + " " + id).getDouble());
+            values.put(
+                new SignalID(SignalType.STEER, (int) id),
+                table.get("Data/" + i + " " + SignalType.STEER + " " + id).getDouble());
+          }
+          try {
+            values.put(
+                new SignalID(SignalType.GYRO, (int) -1),
+                table.get("Data/" + i + " " + SignalType.GYRO + " " + GYRO_MODULE_ID).getDouble());
+          } catch (NullPointerException e) {
+            // We don't have a gyro this loop ig
+          }
+          sampledStates.add(new Samples(timestamp, values));
+        } catch (NullPointerException e) {
+          System.out.println("Failed to get all swerve signals at " + timestamp);
+        }
+      }
+    }
+  }
+
+  public void updateInputs(OdometryThreadIOInputs inputs, double lastTimestamp);
+
+  public void start();
+
+  public void interrupt();
+}

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -37,10 +37,10 @@ import java.util.stream.Collectors;
 /**
  * Provides an interface for high frequency sampling of Phoenix devices.
  *
- * <p>This version is intended for Phoenix 6 devices on both the RIO and CANivore buses. CAN FD
+ * <p>This version is intended for Phoenix 6 devices on the CANivore bus. CAN FD
  * compliant devices are required (TalonFX, CANCoder, Pigeon 2.0, CANdle) due to the use of the
- * "waitForAll" blocking method to enable more consistent sampling. This also allows Phoenix Pro
- * users to benefit from lower latency between devices using CANivore time synchronization.
+ * "waitForAll" blocking method to enable more consistent sampling. This also allows us
+ * to benefit from lower latency between devices using CANivore time synchronization.
  */
 public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
   public static final double ODOMETRY_FREQUENCY_HZ = 250.0;
@@ -53,7 +53,7 @@ public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
     // But we don't!
   }
 
-  /** modID should be GYRO_MODULE_ID for the gyro signal */
+  /** modID should be OdometryThreadIO.GYRO_MODULE_ID for the gyro signal */
   public record SignalID(SignalType type, int modID) {}
 
   public record Registration(

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -43,6 +43,8 @@ import java.util.stream.Collectors;
  * users to benefit from lower latency between devices using CANivore time synchronization.
  */
 public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
+  public static final double ODOMETRY_FREQUENCY_HZ = 250.0;
+
   public enum SignalType {
     DRIVE,
     STEER,
@@ -163,7 +165,7 @@ public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
           () -> {
             Tracer.trace(
                 "wait for all",
-                () -> BaseStatusSignal.waitForAll(2.0 / Module.ODOMETRY_FREQUENCY_HZ, signalArr));
+                () -> BaseStatusSignal.waitForAll(2.0 / ODOMETRY_FREQUENCY_HZ, signalArr));
             try {
               writeLock.lock();
               var filteredSignals =

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -1,0 +1,212 @@
+// Copyright 2021-2024 FRC 6328, FRC 8033, Kevin Clark
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.BaseStatusSignal;
+import com.ctre.phoenix6.CANBus;
+import com.ctre.phoenix6.StatusCode;
+import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.hardware.ParentDevice;
+import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Sets;
+
+import edu.wpi.first.wpilibj.RobotController;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+import frc.robot.utils.Tracer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+/**
+ * Provides an interface for high frequency sampling of Phoenix devices.
+ *
+ * <p>This version is intended for Phoenix 6 devices on both the RIO and CANivore buses. CAN FD
+ * compliant devices are required (TalonFX, CANCoder, Pigeon 2.0, CANdle) due to the use of the
+ * "waitForAll" blocking method to enable more consistent sampling. This also allows Phoenix Pro
+ * users to benefit from lower latency between devices using CANivore time synchronization.
+ */
+public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
+  public enum SignalType {
+    DRIVE,
+    STEER,
+    GYRO;
+    // In theory we could measure other types of info in this thread
+    // But we don't!
+  }
+
+  /** modID should be GYRO_MODULE_ID for the gyro signal */
+  public record SignalID(SignalType type, int modID) {}
+
+  public record Registration(
+      ParentDevice device,
+      Optional<ModuleConstants> moduleConstants,
+      SignalType type,
+      Set<BaseStatusSignal> signals) {}
+
+  /** modID should be GYRO_MODULE_ID for the gyro signal */
+  public record RegisteredSignal(BaseStatusSignal signal, int modID, SignalType type) {}
+
+  public record Samples(double timestamp, Map<SignalID, Double> values) {}
+
+  private final ReadWriteLock journalLock = new ReentrantReadWriteLock(true);
+
+  private final Set<RegisteredSignal> registeredSignals = Sets.newHashSet();
+  private BaseStatusSignal[] signalArr = new StatusSignal[0];
+  private final Queue<Samples> journal;
+
+  private static PhoenixOdometryThread instance = null;
+
+  public static PhoenixOdometryThread getInstance() {
+    if (instance == null) {
+      instance = new PhoenixOdometryThread();
+    }
+    return instance;
+  }
+
+  // Used for testing
+  protected static PhoenixOdometryThread createWithJournal(final Queue<Samples> journal) {
+    return new PhoenixOdometryThread(journal);
+  }
+
+  private PhoenixOdometryThread(final Queue<Samples> journal) {
+    setName("PhoenixOdometryThread");
+    setDaemon(true);
+
+    this.journal = journal;
+  }
+
+  private PhoenixOdometryThread() {
+    this(EvictingQueue.create(20));
+  }
+
+  public void registerSignals(Collection<Registration> registrations) {
+    registerSignals(registrations.toArray(new Registration[] {}));
+  }
+
+  // Returns a handle which can be used to collect the last 20 signal results
+  public void registerSignals(Registration... registrations) {
+    var writeLock = journalLock.writeLock();
+
+    try {
+      writeLock.lock();
+
+      for (var registration : registrations) {
+        assert CANBus.isNetworkFD(registration.device.getNetwork()) : "Only CAN FDs supported";
+
+        registeredSignals.addAll(
+            registration.signals.stream()
+                .map(
+                    s ->
+                        new RegisteredSignal(
+                            s,
+                            registration.moduleConstants().isPresent()
+                                ? registration.moduleConstants().get().id()
+                                : GYRO_MODULE_ID,
+                            registration.type()))
+                .toList());
+        registration.signals.stream()
+            .forEach(
+                (s) -> {
+                  signalArr = Arrays.copyOf(signalArr, signalArr.length + 1);
+                  signalArr[signalArr.length - 1] = s;
+                });
+      }
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  public List<Samples> samplesSince(double timestamp) {
+    return Tracer.trace(
+        "samples since",
+        () -> {
+          var readLock = journalLock.readLock();
+          try {
+            readLock.lock();
+
+            return Tracer.trace(
+                "stream timestamps",
+                () ->
+                    journal.stream()
+                        .filter(s -> s.timestamp > timestamp)
+                        .collect(Collectors.toUnmodifiableList()));
+          } finally {
+            readLock.unlock();
+          }
+        });
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      // Wait for updates from all signals
+      var writeLock = journalLock.writeLock();
+      Tracer.trace(
+          "Odometry Thread",
+          () -> {
+            Tracer.trace(
+                "wait for all",
+                () -> BaseStatusSignal.waitForAll(2.0 / Module.ODOMETRY_FREQUENCY_HZ, signalArr));
+            try {
+              writeLock.lock();
+              var filteredSignals =
+                  registeredSignals.stream()
+                      .filter(s -> s.signal().getStatus().equals(StatusCode.OK))
+                      .collect(Collectors.toSet());
+              journal.add(
+                  new Samples(
+                      timestampFor(filteredSignals),
+                      filteredSignals.stream()
+                          .collect(
+                              Collectors.toUnmodifiableMap(
+                                  s -> new SignalID(s.type(), s.modID()),
+                                  s -> s.signal().getValueAsDouble()))));
+            } finally {
+              writeLock.unlock();
+            }
+          });
+    }
+  }
+
+  private double timestampFor(Set<RegisteredSignal> signals) {
+    double timestamp = RobotController.getFPGATime() / 1e6;
+
+    final double totalLatency =
+        signals.stream().mapToDouble(s -> s.signal().getTimestamp().getLatency()).sum();
+
+    // Account for mean latency for a "good enough" timestamp
+    if (!signals.isEmpty()) {
+      timestamp -= totalLatency / signals.size();
+    }
+
+    return timestamp;
+  }
+
+  @Override
+  public void updateInputs(OdometryThreadIOInputs inputs, double lastTimestamp) {
+    inputs.sampledStates = samplesSince(lastTimestamp);
+  }
+
+  @Override
+  public void start() {
+    super.start();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -20,7 +20,6 @@ import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.hardware.ParentDevice;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Sets;
-
 import edu.wpi.first.wpilibj.RobotController;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.utils.Tracer;

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -37,10 +37,10 @@ import java.util.stream.Collectors;
 /**
  * Provides an interface for high frequency sampling of Phoenix devices.
  *
- * <p>This version is intended for Phoenix 6 devices on the CANivore bus. CAN FD
- * compliant devices are required (TalonFX, CANCoder, Pigeon 2.0, CANdle) due to the use of the
- * "waitForAll" blocking method to enable more consistent sampling. This also allows us
- * to benefit from lower latency between devices using CANivore time synchronization.
+ * <p>This version is intended for Phoenix 6 devices on the CANivore bus. CAN FD compliant devices
+ * are required (TalonFX, CANCoder, Pigeon 2.0, CANdle) due to the use of the "waitForAll" blocking
+ * method to enable more consistent sampling. This also allows us to benefit from lower latency
+ * between devices using CANivore time synchronization.
  */
 public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
   public static final double ODOMETRY_FREQUENCY_HZ = 250.0;

--- a/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
+++ b/src/main/java/frc/robot/subsystems/swerve/PhoenixOdometryThread.java
@@ -102,7 +102,7 @@ public class PhoenixOdometryThread extends Thread implements OdometryThreadIO {
     registerSignals(registrations.toArray(new Registration[] {}));
   }
 
-  // Returns a handle which can be used to collect the last 20 signal results
+  /** Adds each registration to the signals array and set */
   public void registerSignals(Registration... registrations) {
     var writeLock = journalLock.writeLock();
 

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
@@ -1,0 +1,99 @@
+package frc.robot.subsystems.swerve;
+
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.util.Units;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+
+public interface SwerveConstants {
+  // Drivebase Constants
+  public double getMaxLinearSpeed();
+
+  public double getMaxLinearAcceleration();
+
+  public double getTrackWidthX();
+
+  public double getTrackWidthY();
+
+  public default double getDriveBaseRadius() {
+    return Math.hypot(getTrackWidthX() / 2.0, getTrackWidthY() / 2.0);
+  }
+
+  public default double getMaxAngularSpeed() {
+    return getMaxLinearSpeed() / getDriveBaseRadius();
+  }
+  /**
+   * Derives angular acceleration from linear acceleration. This is a bad model because the MOI of a
+   * robot is different from its mass.
+   */
+  public default double getMaxAngularAcceleration() {
+    return getMaxLinearAcceleration() / getDriveBaseRadius();
+  }
+  /** Returns an array of module translations. */
+  public default Translation2d[] getModuleTranslations() {
+    return new Translation2d[] {
+      new Translation2d(getTrackWidthX() / 2.0, getTrackWidthY() / 2.0),
+      new Translation2d(getTrackWidthX() / 2.0, -getTrackWidthY() / 2.0),
+      new Translation2d(-getTrackWidthX() / 2.0, getTrackWidthY() / 2.0),
+      new Translation2d(-getTrackWidthX() / 2.0, -getTrackWidthY() / 2.0)
+    };
+  }
+
+  public int getGyroID();
+
+  public double getHeadingVelocityKP();
+
+  public double getHeadingVoltageKP();
+
+  public ModuleConstants getFrontLeftModule();
+
+  public ModuleConstants getFrontRightModule();
+
+  public ModuleConstants getBackLeftModule();
+
+  public ModuleConstants getBackRightModule();
+
+  public AprilTagFieldLayout getFieldTagLayout();
+
+  public VisionConstants[] getVisionConstants();
+
+  public default double getWheelRadiusMeters() {
+    return Units.inchesToMeters(2.0);
+  }
+
+  public double getDriveGearRatio();
+
+  public default double getDriveRotorToMeters() {
+    return getDriveGearRatio() / (getWheelRadiusMeters() * 2 * Math.PI);
+  }
+  /** SDS Mk4 line default. */
+  public default double getTurnGearRatio() {
+    return 150.0 / 7.0;
+  }
+  /** Defaults to inverted ie Mk4i, Mk4n. */
+  public default boolean getTurnMotorInverted() {
+    return true;
+  }
+
+  public TalonFXConfiguration getDriveConfig();
+
+  public TalonFXConfiguration getTurnConfig(int cancoderID);
+
+  public CANcoderConfiguration getCancoderConfig(Rotation2d cancoderOffset);
+
+  public default Matrix<N3, N1> getVisionPointBlankStdDevs() {
+    return new Matrix<N3, N1>(Nat.N3(), Nat.N1(), new double[] {0.4, 0.4, 1});
+  }
+
+  public default double getVisionDistanceFactor() {
+    return 0.5;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
@@ -10,35 +10,47 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 
-public interface SwerveConstants {
+public abstract class SwerveConstants {
+  private static boolean instantiated = false;
+  private static final Alert multipleInstancesAlert = new Alert("Multiple Swerve Constants Files", AlertType.kError);
+
+  public SwerveConstants() {
+    if (instantiated) {
+      multipleInstancesAlert.set(true);
+    }
+    instantiated = true;
+  }
+
   // Drivebase Constants
-  public double getMaxLinearSpeed();
+  public abstract double getMaxLinearSpeed();
 
-  public double getMaxLinearAcceleration();
+  public abstract double getMaxLinearAcceleration();
 
-  public double getTrackWidthX();
+  public abstract double getTrackWidthX();
 
-  public double getTrackWidthY();
+  public abstract double getTrackWidthY();
 
-  public default double getDriveBaseRadius() {
+  public double getDriveBaseRadius() {
     return Math.hypot(getTrackWidthX() / 2.0, getTrackWidthY() / 2.0);
   }
 
-  public default double getMaxAngularSpeed() {
+  public double getMaxAngularSpeed() {
     return getMaxLinearSpeed() / getDriveBaseRadius();
   }
   /**
    * Derives angular acceleration from linear acceleration. This is a bad model because the MOI of a
    * robot is different from its mass.
    */
-  public default double getMaxAngularAcceleration() {
+  public double getMaxAngularAcceleration() {
     return getMaxLinearAcceleration() / getDriveBaseRadius();
   }
   /** Returns an array of module translations. */
-  public default Translation2d[] getModuleTranslations() {
+  public Translation2d[] getModuleTranslations() {
     return new Translation2d[] {
       new Translation2d(getTrackWidthX() / 2.0, getTrackWidthY() / 2.0),
       new Translation2d(getTrackWidthX() / 2.0, -getTrackWidthY() / 2.0),
@@ -47,53 +59,53 @@ public interface SwerveConstants {
     };
   }
 
-  public int getGyroID();
+  public abstract int getGyroID();
 
-  public double getHeadingVelocityKP();
+  public abstract double getHeadingVelocityKP();
 
-  public double getHeadingVoltageKP();
+  public abstract double getHeadingVoltageKP();
 
-  public ModuleConstants getFrontLeftModule();
+  public abstract ModuleConstants getFrontLeftModule();
 
-  public ModuleConstants getFrontRightModule();
+  public abstract ModuleConstants getFrontRightModule();
 
-  public ModuleConstants getBackLeftModule();
+  public abstract ModuleConstants getBackLeftModule();
 
-  public ModuleConstants getBackRightModule();
+  public abstract ModuleConstants getBackRightModule();
 
-  public AprilTagFieldLayout getFieldTagLayout();
+  public abstract AprilTagFieldLayout getFieldTagLayout();
 
-  public VisionConstants[] getVisionConstants();
+  public abstract VisionConstants[] getVisionConstants();
 
-  public default double getWheelRadiusMeters() {
+  public double getWheelRadiusMeters() {
     return Units.inchesToMeters(2.0);
   }
 
-  public double getDriveGearRatio();
+  public abstract double getDriveGearRatio();
 
-  public default double getDriveRotorToMeters() {
+  public double getDriveRotorToMeters() {
     return getDriveGearRatio() / (getWheelRadiusMeters() * 2 * Math.PI);
   }
   /** SDS Mk4 line default. */
-  public default double getTurnGearRatio() {
+  public double getTurnGearRatio() {
     return 150.0 / 7.0;
   }
   /** Defaults to inverted ie Mk4i, Mk4n. */
-  public default boolean getTurnMotorInverted() {
+  public boolean getTurnMotorInverted() {
     return true;
   }
 
-  public TalonFXConfiguration getDriveConfig();
+  public abstract TalonFXConfiguration getDriveConfig();
 
-  public TalonFXConfiguration getTurnConfig(int cancoderID);
+  public abstract TalonFXConfiguration getTurnConfig(int cancoderID);
 
-  public CANcoderConfiguration getCancoderConfig(Rotation2d cancoderOffset);
+  public abstract CANcoderConfiguration getCancoderConfig(Rotation2d cancoderOffset);
 
-  public default Matrix<N3, N1> getVisionPointBlankStdDevs() {
+  public Matrix<N3, N1> getVisionPointBlankStdDevs() {
     return new Matrix<N3, N1>(Nat.N3(), Nat.N1(), new double[] {0.4, 0.4, 1});
   }
 
-  public default double getVisionDistanceFactor() {
+  public double getVisionDistanceFactor() {
     return 0.5;
   }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
@@ -17,7 +17,8 @@ import frc.robot.subsystems.vision.Vision.VisionConstants;
 
 public abstract class SwerveConstants {
   private static boolean instantiated = false;
-  private static final Alert multipleInstancesAlert = new Alert("Multiple Swerve Constants Files", AlertType.kError);
+  private static final Alert multipleInstancesAlert =
+      new Alert("Multiple Swerve Constants Files", AlertType.kError);
 
   public SwerveConstants() {
     if (instantiated) {

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveConstants.java
@@ -15,6 +15,11 @@ import edu.wpi.first.wpilibj.Alert.AlertType;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 
+/**
+ * A template for constants for a swerve drivetrain. This template presumes rectangular modules that
+ * are symmetric around the center of the robot, talonfxs + cancoders, and that all modules have the
+ * same gear ratios Subclass this to make constants for a specific robot.
+ */
 public abstract class SwerveConstants {
   private static boolean instantiated = false;
   private static final Alert multipleInstancesAlert =

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -1,0 +1,57 @@
+// Copyright 2021-2023 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 3 as published by the Free Software Foundation or
+// available in the root directory of this project.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+package frc.robot.subsystems.swerve;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.subsystems.swerve.Module.ModuleConstants;
+import frc.robot.subsystems.swerve.OdometryThreadIO.OdometryThreadIOInputs;
+
+public class SwerveSubsystem extends SubsystemBase {
+  // Drivebase constants
+  public static final double MAX_LINEAR_SPEED = Units.feetToMeters(16);
+  public static final double MAX_LINEAR_ACCELERATION = 8.0;
+  public static final double TRACK_WIDTH_X = Units.inchesToMeters(21.75);
+  public static final double TRACK_WIDTH_Y = Units.inchesToMeters(21.25);
+  public static final double DRIVE_BASE_RADIUS =
+      Math.hypot(TRACK_WIDTH_X / 2.0, TRACK_WIDTH_Y / 2.0);
+  public static final double MAX_ANGULAR_SPEED = MAX_LINEAR_SPEED / DRIVE_BASE_RADIUS;
+  public static final double MAX_ANGULAR_ACCELERATION = MAX_LINEAR_ACCELERATION / DRIVE_BASE_RADIUS;
+  public static final double MAX_AUTOAIM_SPEED = MAX_LINEAR_SPEED / 4;
+  // Hardware constants
+  public static final int PIGEON_ID = 0;
+
+  public static final double HEADING_VELOCITY_KP = 4.0;
+  public static final double HEADING_VOLTAGE_KP = 4.0;
+
+  public static final ModuleConstants frontLeft =
+      new ModuleConstants(0, "Front Left", 0, 1, 0, Rotation2d.fromRotations(0.377930));
+  public static final ModuleConstants frontRight =
+      new ModuleConstants(1, "Front Right", 2, 3, 1, Rotation2d.fromRotations(-0.071289));
+  public static final ModuleConstants backLeft =
+      new ModuleConstants(2, "Back Left", 4, 5, 2, Rotation2d.fromRotations(0.550781));
+  public static final ModuleConstants backRight =
+      new ModuleConstants(3, "Back Right", 6, 7, 3, Rotation2d.fromRotations(-0.481689));
+
+  private final GyroIO gyroIO;
+  private final GyroIOInputsAutoLogged gyroInputs = new GyroIOInputsAutoLogged();
+  private final Module[] modules; // FL, FR, BL, BR
+  private final OdometryThreadIO odoThread;
+  private final OdometryThreadIOInputs odoThreadInputs = new OdometryThreadIOInputs();
+
+  private SwerveDriveKinematics kinematics = new SwerveDriveKinematics(new Translation2d[0]);
+}

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -24,6 +24,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.swerve.OdometryThreadIO.OdometryThreadIOInputs;
@@ -476,7 +477,10 @@ public class SwerveSubsystem extends SubsystemBase {
     return this.run(
         () -> {
           ChassisSpeeds speed = speeds.get();
-          speed.toRobotRelativeSpeeds(getRotation());
+          speed.toRobotRelativeSpeeds(
+              DriverStation.getAlliance().orElse(Alliance.Blue) == Alliance.Blue
+                  ? getPose().getRotation()
+                  : getPose().getRotation().minus(Rotation2d.fromDegrees(180)));
           this.drive(speed, true, new double[4], new double[4]);
         });
   }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -13,6 +13,7 @@
 
 package frc.robot.subsystems.swerve;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
@@ -37,6 +38,8 @@ public class SwerveSubsystem extends SubsystemBase {
 
   public static final double HEADING_VELOCITY_KP = 4.0;
   public static final double HEADING_VOLTAGE_KP = 4.0;
+
+  public static AprilTagFieldLayout fieldTags;
 
   public static final ModuleConstants frontLeft =
       new ModuleConstants(0, "Front Left", 0, 1, 0, Rotation2d.fromRotations(0.377930));

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -12,7 +12,6 @@
 
 package frc.robot.subsystems.swerve;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -279,7 +278,9 @@ public class SwerveSubsystem extends SubsystemBase {
   private void updateVision() {
     for (var camera : cameras) {
       boolean isNewResult = Math.abs(camera.inputs.timestamp - lastEstTimestamp) > 1e-5;
-      var estPose = camera.update(camera.inputs.targets, camera.inputs.timestamp, constants.getFieldTagLayout());
+      var estPose =
+          camera.update(
+              camera.inputs.targets, camera.inputs.timestamp, constants.getFieldTagLayout());
       if (estPose.isPresent()) {
         var visionPose = estPose.get().estimatedPose;
         // Sets the pose on the sim field
@@ -294,7 +295,7 @@ public class SwerveSubsystem extends SubsystemBase {
                 constants.getVisionPointBlankStdDevs(),
                 constants.getVisionDistanceFactor()));
         Pose3d[] tagPose3ds = new Pose3d[camera.inputs.targets.size()];
-        for (int i = 0; i < camera.inputs.targets.size(); i ++) {
+        for (int i = 0; i < camera.inputs.targets.size(); i++) {
           var target = camera.inputs.targets.get(i);
           tagPose3ds[i] = constants.getFieldTagLayout().getTagPose(target.getFiducialId()).get();
         }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -17,7 +17,6 @@ import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
@@ -52,7 +51,7 @@ public class SwerveSubsystem extends SubsystemBase {
   private final OdometryThreadIO odoThread;
   private final OdometryThreadIOInputs odoThreadInputs = new OdometryThreadIOInputs();
 
-  private SwerveDriveKinematics kinematics = new SwerveDriveKinematics(new Translation2d[0]);
+  private SwerveDriveKinematics kinematics;
 
   private final Vision[] cameras;
   public static AprilTagFieldLayout fieldTags;
@@ -68,8 +67,7 @@ public class SwerveSubsystem extends SubsystemBase {
 
   private Rotation2d rawGyroRotation = new Rotation2d();
   private Rotation2d lastGyroRotation = new Rotation2d();
-  private SwerveDrivePoseEstimator estimator =
-      new SwerveDrivePoseEstimator(kinematics, rawGyroRotation, lastModulePositions, new Pose2d());
+  private SwerveDrivePoseEstimator estimator;
   private double lastEstTimestamp = 0.0;
   private double lastOdometryUpdateTimestamp = 0.0;
 
@@ -84,6 +82,10 @@ public class SwerveSubsystem extends SubsystemBase {
       ModuleIO[] moduleIOs,
       OdometryThreadIO odoThread) {
     this.constants = constants;
+    this.kinematics = new SwerveDriveKinematics(constants.getModuleTranslations());
+    this.estimator =
+        new SwerveDrivePoseEstimator(
+            kinematics, rawGyroRotation, lastModulePositions, new Pose2d());
     this.gyroIO = gyroIO;
     this.odoThread = odoThread;
     odoThread.start();

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -13,14 +13,44 @@
 
 package frc.robot.subsystems.swerve;
 
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.littletonrobotics.junction.Logger;
+import org.photonvision.targeting.PhotonPipelineResult;
+
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.Vector;
+import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Filesystem;
+import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.subsystems.swerve.Module.ModuleConstants;
 import frc.robot.subsystems.swerve.OdometryThreadIO.OdometryThreadIOInputs;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.Samples;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalID;
+import frc.robot.subsystems.swerve.PhoenixOdometryThread.SignalType;
+import frc.robot.subsystems.vision.Vision;
+import frc.robot.subsystems.vision.VisionHelper;
+import frc.robot.subsystems.vision.VisionIO;
+import frc.robot.subsystems.vision.VisionIOSim;
+import frc.robot.utils.Tracer;
 
 public class SwerveSubsystem extends SubsystemBase {
   // Drivebase constants
@@ -38,23 +68,254 @@ public class SwerveSubsystem extends SubsystemBase {
 
   public static final double HEADING_VELOCITY_KP = 4.0;
   public static final double HEADING_VOLTAGE_KP = 4.0;
-
-  public static AprilTagFieldLayout fieldTags;
-
+  
   public static final ModuleConstants frontLeft =
-      new ModuleConstants(0, "Front Left", 0, 1, 0, Rotation2d.fromRotations(0.377930));
+  new ModuleConstants(0, "Front Left", 0, 1, 0, Rotation2d.fromRotations(0.377930));
   public static final ModuleConstants frontRight =
-      new ModuleConstants(1, "Front Right", 2, 3, 1, Rotation2d.fromRotations(-0.071289));
+  new ModuleConstants(1, "Front Right", 2, 3, 1, Rotation2d.fromRotations(-0.071289));
   public static final ModuleConstants backLeft =
-      new ModuleConstants(2, "Back Left", 4, 5, 2, Rotation2d.fromRotations(0.550781));
+  new ModuleConstants(2, "Back Left", 4, 5, 2, Rotation2d.fromRotations(0.550781));
   public static final ModuleConstants backRight =
-      new ModuleConstants(3, "Back Right", 6, 7, 3, Rotation2d.fromRotations(-0.481689));
-
+  new ModuleConstants(3, "Back Right", 6, 7, 3, Rotation2d.fromRotations(-0.481689));
+  
   private final GyroIO gyroIO;
   private final GyroIOInputsAutoLogged gyroInputs = new GyroIOInputsAutoLogged();
   private final Module[] modules; // FL, FR, BL, BR
   private final OdometryThreadIO odoThread;
   private final OdometryThreadIOInputs odoThreadInputs = new OdometryThreadIOInputs();
-
+  
   private SwerveDriveKinematics kinematics = new SwerveDriveKinematics(new Translation2d[0]);
+  
+  private final Vision[] cameras;
+  public static AprilTagFieldLayout fieldTags;
+
+  /** For delta tracking with PhoenixOdometryThread* */
+  private SwerveModulePosition[] lastModulePositions =
+      new SwerveModulePosition[] {
+        new SwerveModulePosition(),
+        new SwerveModulePosition(),
+        new SwerveModulePosition(),
+        new SwerveModulePosition()
+      };
+  private Rotation2d rawGyroRotation = new Rotation2d();
+  private Rotation2d lastGyroRotation = new Rotation2d();
+  private SwerveDrivePoseEstimator estimator =
+      new SwerveDrivePoseEstimator(kinematics, rawGyroRotation, lastModulePositions, new Pose2d());
+  private double lastEstTimestamp = 0.0;
+  private double lastOdometryUpdateTimestamp = 0.0;
+  
+  // Need this annotation so the alert doesn't get mad
+  @SuppressWarnings("resource")
+  public SwerveSubsystem(
+      GyroIO gyroIO, VisionIO[] visionIOs, ModuleIO[] moduleIOs, OdometryThreadIO odoThread) {
+    this.gyroIO = gyroIO;
+    this.odoThread = odoThread;
+    odoThread.start();
+    cameras = new Vision[visionIOs.length];
+    modules = new Module[moduleIOs.length];
+
+    for (int i = 0; i < moduleIOs.length; i++) {
+      modules[i] = new Module(moduleIOs[i]);
+    }
+    for (int i = 0; i < visionIOs.length; i++) {
+      cameras[i] = new Vision(visionIOs[i]);
+    }
+
+    // global static is mildly questionable
+    VisionIOSim.pose = () -> Pose3d.kZero;//this::getPose3d;
+
+    // TODO: update to 2025 field
+    try {
+      fieldTags =
+          new AprilTagFieldLayout(
+              Filesystem.getDeployDirectory()
+                  .toPath()
+                  .resolve("vision" + File.separator + "2024-crescendo.json"));
+      System.out.println("Successfully loaded tag map");
+    } catch (Exception e) {
+      System.err.println("Failed to load custom tag map");
+      new Alert("Failed to load custom tag map", AlertType.kWarning).set(true);
+      fieldTags = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+    }
+  }
+
+  public void periodic() {
+    Tracer.trace(
+        "SwervePeriodic",
+        () -> {
+          for (var camera : cameras) {
+            Tracer.trace("Update cam inputs", camera::updateInputs);
+            Tracer.trace("Process cam inputs", camera::processInputs);
+          }
+          Tracer.trace(
+              "Update odo inputs",
+              () -> odoThread.updateInputs(odoThreadInputs, lastOdometryUpdateTimestamp));
+          Logger.processInputs("Async Odo", odoThreadInputs);
+          if (!odoThreadInputs.sampledStates.isEmpty()) {
+            lastOdometryUpdateTimestamp =
+                odoThreadInputs
+                    .sampledStates
+                    .get(odoThreadInputs.sampledStates.size() - 1)
+                    .timestamp();
+          }
+          Tracer.trace("update gyro inputs", () -> gyroIO.updateInputs(gyroInputs));
+          for (int i = 0; i < modules.length; i++) {
+            Tracer.trace(
+                "SwerveModule update inputs from " + modules[i].getPrefix() + " Module",
+                modules[i]::updateInputs);
+          }
+          Logger.processInputs("Swerve/Gyro", gyroInputs);
+          for (int i = 0; i < modules.length; i++) {
+            Tracer.trace(
+                "SwerveModule periodic from " + modules[i].getPrefix() + " Module",
+                modules[i]::periodic);
+          }
+
+          // Stop moving when disabled
+          if (DriverStation.isDisabled()) {
+            for (var module : modules) {
+              module.stop();
+            }
+          }
+          // Log empty setpoint states when disabled
+          if (DriverStation.isDisabled()) {
+            Logger.recordOutput("SwerveStates/Setpoints", new SwerveModuleState[] {});
+            Logger.recordOutput("SwerveStates/SetpointsOptimized", new SwerveModuleState[] {});
+          }
+
+          Tracer.trace("Update odometry", this::updateOdometry);
+          Tracer.trace("Update vision", this::updateVision);
+        });
+  }
+
+  private void updateOdometry() {
+    Logger.recordOutput("Swerve/Updates Since Last", odoThreadInputs.sampledStates.size());
+    var sampleStates = odoThreadInputs.sampledStates;
+    if (sampleStates.size() == 0 || sampleStates.get(0).values().isEmpty())
+      sampleStates = getSyncSamples();
+    for (var sample : sampleStates) {
+      // Read wheel deltas from each module
+      SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
+      SwerveModulePosition[] moduleDeltas =
+          new SwerveModulePosition[4]; // change in positions since the last update
+      boolean hasNullModulePosition = false;
+      // Technically we could have not 4 modules worth of data here but im not dealing w that
+      for (int moduleIndex = 0; moduleIndex < 4; moduleIndex++) {
+        var dist = sample.values().get(new SignalID(SignalType.DRIVE, moduleIndex));
+        if (dist == null) {
+          // No value at this timestamp
+          hasNullModulePosition = true;
+
+          Logger.recordOutput("Odometry/Received Update From Module " + moduleIndex, false);
+          break;
+        }
+        var rot = sample.values().get(new SignalID(SignalType.STEER, moduleIndex));
+        if (rot == null) {
+          // No value at this timestamp
+          hasNullModulePosition = true;
+
+          Logger.recordOutput("Odometry/Received Update From Module " + moduleIndex, false);
+          break;
+        }
+        modulePositions[moduleIndex] =
+            new SwerveModulePosition(
+                dist, Rotation2d.fromRotations(rot)); // gets positions from the thread, NOT inputs
+        Logger.recordOutput("Odometry/Received Update From Module " + moduleIndex, true);
+        moduleDeltas[moduleIndex] =
+            new SwerveModulePosition(
+                modulePositions[moduleIndex].distanceMeters
+                    - lastModulePositions[moduleIndex].distanceMeters,
+                modulePositions[moduleIndex].angle);
+        lastModulePositions[moduleIndex] = modulePositions[moduleIndex];
+      }
+      if (hasNullModulePosition) {
+        if (!gyroInputs.connected
+            || sample.values().get(new SignalID(SignalType.GYRO, OdometryThreadIO.GYRO_MODULE_ID))
+                == null) {
+          Logger.recordOutput("Odometry/Received Gyro Update", false);
+          // no modules and no gyro so we're just sad :(
+        } else {
+          Logger.recordOutput("Odometry/Received Gyro Update", true);
+          // null here is checked by if clause
+          rawGyroRotation =
+              Rotation2d.fromDegrees(sample.values().get(new SignalID(SignalType.GYRO, -1)));
+          lastGyroRotation = rawGyroRotation;
+          Logger.recordOutput("Odometry/Gyro Rotation", lastGyroRotation);
+          Tracer.trace(
+              "update estimator",
+              () ->
+                  estimator.updateWithTime(
+                      sample.timestamp(), rawGyroRotation, lastModulePositions));
+        }
+        continue;
+      }
+
+      // The twist represents the motion of the robot since the last
+      // sample in x, y, and theta based only on the modules, without
+      // the gyro. The gyro is always disconnected in simulation.
+      Twist2d twist = kinematics.toTwist2d(moduleDeltas);
+      if (!gyroInputs.connected
+          || sample.values().get(new SignalID(SignalType.GYRO, OdometryThreadIO.GYRO_MODULE_ID))
+              == null) {
+        Logger.recordOutput("Odometry/Received Gyro Update", false);
+        // We don't have a complete set of data, so just use the module rotations
+        rawGyroRotation = rawGyroRotation.plus(new Rotation2d(twist.dtheta));
+      } else {
+        Logger.recordOutput("Odometry/Received Gyro Update", true);
+        rawGyroRotation =
+            Rotation2d.fromDegrees(
+                sample
+                    .values()
+                    .get(new SignalID(SignalType.GYRO, OdometryThreadIO.GYRO_MODULE_ID)));
+        twist =
+            new Twist2d(twist.dx, twist.dy, rawGyroRotation.minus(lastGyroRotation).getRadians());
+      }
+      // Apply the twist (change since last sample) to the current pose
+      lastGyroRotation = rawGyroRotation;
+      Logger.recordOutput("Odometry/Gyro Rotation", lastGyroRotation);
+      // Apply update
+      estimator.updateWithTime(sample.timestamp(), rawGyroRotation, modulePositions);
+    }
+  }
+
+  /** 
+   * Generates a set of samples without using the async thread.
+   * Makes lots of Objects, so be careful when using it irl!
+   */
+  private List<Samples> getSyncSamples() {
+    return List.of(
+        new Samples(
+            Logger.getTimestamp(),
+            Map.of(
+                new SignalID(SignalType.DRIVE, 0), modules[0].getPosition().distanceMeters,
+                new SignalID(SignalType.STEER, 0), modules[0].getPosition().angle.getRotations(),
+                new SignalID(SignalType.DRIVE, 1), modules[1].getPosition().distanceMeters,
+                new SignalID(SignalType.STEER, 1), modules[1].getPosition().angle.getRotations(),
+                new SignalID(SignalType.DRIVE, 2), modules[2].getPosition().distanceMeters,
+                new SignalID(SignalType.STEER, 2), modules[2].getPosition().angle.getRotations(),
+                new SignalID(SignalType.DRIVE, 3), modules[3].getPosition().distanceMeters,
+                new SignalID(SignalType.STEER, 3), modules[3].getPosition().angle.getRotations(),
+                new SignalID(SignalType.GYRO, PhoenixOdometryThread.GYRO_MODULE_ID),
+                    gyroInputs.yawPosition.getRotations())));
+  }
+
+  private void updateVision() {
+    for (var camera : cameras) {
+      boolean isNewResult = Math.abs(camera.inputs.timestamp - lastEstTimestamp) > 1e-5;
+      try {
+        var estPose = camera.update(camera.inputs.targets, camera.inputs.timestamp);
+        var visionPose = estPose.get().estimatedPose;
+        // Sets the pose on the sim field
+        camera.setSimPose(estPose, camera, isNewResult);
+        Logger.recordOutput("Vision/Vision Pose From " + camera.getName(), visionPose);
+        Logger.recordOutput("Vision/Vision Pose2d From " + camera.getName(), visionPose.toPose2d());
+        estimator.addVisionMeasurement(
+            visionPose.toPose2d(),
+            camera.inputs.timestamp,
+            VisionHelper.findVisionMeasurementStdDevs(estPose.get()));
+        if (isNewResult) lastEstTimestamp = camera.inputs.timestamp;
+      } catch (NoSuchElementException e) {
+      }
+    }
+  }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -375,6 +375,7 @@ public class SwerveSubsystem extends SubsystemBase {
     // Calculate module setpoints
     speeds.discretize(0.02);
     final SwerveModuleState[] setpointStates = kinematics.toSwerveModuleStates(speeds);
+    Logger.recordOutput("SwerveStates/Setpoints", setpointStates);
     SwerveDriveKinematics.desaturateWheelSpeeds(setpointStates, MAX_LINEAR_SPEED);
 
     Logger.recordOutput("Swerve/Target Speeds", speeds);
@@ -420,7 +421,6 @@ public class SwerveSubsystem extends SubsystemBase {
     }
 
     // Log setpoint states
-    Logger.recordOutput("SwerveStates/Setpoints", setpointStates);
     Logger.recordOutput("SwerveStates/ForceSetpoints", forceSetpoints);
     Logger.recordOutput("SwerveStates/SetpointsOptimized", optimizedSetpointStates);
   }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -384,6 +384,8 @@ public class SwerveSubsystem extends SubsystemBase {
                     setpointStates[i].speedMetersPerSecond * 12.0 / constants.getMaxLinearSpeed(),
                     setpointStates[i].angle),
                 focEnable);
+        // Convert voltage back to m/s
+        optimizedSetpointStates[i].speedMetersPerSecond *= constants.getMaxLinearSpeed() / 12.0;
 
         // Have to put something here to log properly
         forceSetpoints[i] = new SwerveModuleState();

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -44,7 +44,8 @@ public class Vision {
     Logger.processInputs("Apriltag Vision/" + io.getName(), inputs);
   }
 
-  public Optional<EstimatedRobotPose> update(List<PhotonTrackedTarget> targets, double timestamp, AprilTagFieldLayout fieldTags) {
+  public Optional<EstimatedRobotPose> update(
+      List<PhotonTrackedTarget> targets, double timestamp, AprilTagFieldLayout fieldTags) {
     // Skip if we only have 1 target
     // TODO change
     if (targets.size() < 1) {

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -9,15 +9,12 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.math.numbers.N5;
 import edu.wpi.first.math.numbers.N8;
-
 import java.util.List;
 import java.util.Optional;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
-import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
 /** Add your docs here. */

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -12,11 +12,13 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.numbers.N5;
 import edu.wpi.first.math.numbers.N8;
 
+import java.util.List;
 import java.util.Optional;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
 
 /** Add your docs here. */
 public class Vision {
@@ -49,15 +51,16 @@ public class Vision {
     Logger.processInputs("Apriltag Vision/" + io.getName(), inputs);
   }
 
-  public Optional<EstimatedRobotPose> update(PhotonPipelineResult result) {
+  public Optional<EstimatedRobotPose> update(List<PhotonTrackedTarget> targets, double timestamp) {
     // Skip if we only have 1 target
     // TODO change
-    if (result.getTargets().size() < 1) {
+    if (targets.size() < 1) {
       return Optional.empty();
     }
     var estPose =
         VisionHelper.update(
-            result,
+            targets,
+            timestamp,
             inputs.constants.intrinsicsMatrix(),
             inputs.constants.distCoeffs(),
             PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -10,6 +10,8 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.numbers.N5;
+import edu.wpi.first.math.numbers.N8;
+
 import java.util.Optional;
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.EstimatedRobotPose;
@@ -26,7 +28,7 @@ public class Vision {
       String cameraName,
       Transform3d robotToCamera,
       Matrix<N3, N3> intrinsicsMatrix,
-      Matrix<N5, N1> distCoeffs) {}
+      Matrix<N8, N1> distCoeffs) {}
 
   private final VisionIO io;
   public final VisionIOInputsLogged inputs = new VisionIOInputsLogged();

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -5,7 +5,6 @@
 package frc.robot.subsystems.vision;
 
 import edu.wpi.first.math.Matrix;
-import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
@@ -19,10 +18,6 @@ import org.photonvision.targeting.PhotonTrackedTarget;
 
 /** Add your docs here. */
 public class Vision {
-  public static final Matrix<N3, N1> visionPointBlankDevs =
-      new Matrix<N3, N1>(Nat.N3(), Nat.N1(), new double[] {0.4, 0.4, 1});
-  public static final double distanceFactor = 0.5;
-
   public record VisionConstants(
       String cameraName,
       Transform3d robotToCamera,

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -1,0 +1,74 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import java.util.Optional;
+import org.littletonrobotics.junction.Logger;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.targeting.PhotonPipelineResult;
+
+/** Add your docs here. */
+public class Vision {
+  public static final Matrix<N3, N1> visionPointBlankDevs =
+      new Matrix<N3, N1>(Nat.N3(), Nat.N1(), new double[] {0.4, 0.4, 1});
+  public static final double distanceFactor = 0.5;
+
+  public record VisionConstants(
+      String cameraName,
+      Transform3d robotToCamera,
+      Matrix<N3, N3> intrinsicsMatrix,
+      Matrix<N5, N1> distCoeffs) {}
+
+  private final VisionIO io;
+  public final VisionIOInputsLogged inputs = new VisionIOInputsLogged();
+
+  public Vision(final VisionIO io) {
+    this.io = io;
+  }
+
+  public void setSimPose(Optional<EstimatedRobotPose> simEst, Vision camera, boolean newResult) {
+    this.io.setSimPose(simEst, camera, newResult);
+  }
+
+  public void updateInputs() {
+    io.updateInputs(inputs);
+  }
+
+  public void processInputs() {
+    Logger.processInputs("Apriltag Vision/" + io.getName(), inputs);
+  }
+
+  public Optional<EstimatedRobotPose> update(PhotonPipelineResult result) {
+    // Skip if we only have 1 target
+    // TODO change
+    if (result.getTargets().size() < 1) {
+      return Optional.empty();
+    }
+    var estPose =
+        VisionHelper.update(
+            result,
+            inputs.constants.intrinsicsMatrix(),
+            inputs.constants.distCoeffs(),
+            PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
+            inputs.constants.robotToCamera(),
+            inputs.coprocPNPTransform);
+    // // Reject if estimated pose is in the air or ground
+    if (estPose.isPresent() && Math.abs(estPose.get().estimatedPose.getZ()) > 0.25) {
+      return Optional.empty();
+    }
+    return estPose;
+  }
+
+  public String getName() {
+    return io.getName();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -4,6 +4,7 @@
 
 package frc.robot.subsystems.vision;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
@@ -43,7 +44,7 @@ public class Vision {
     Logger.processInputs("Apriltag Vision/" + io.getName(), inputs);
   }
 
-  public Optional<EstimatedRobotPose> update(List<PhotonTrackedTarget> targets, double timestamp) {
+  public Optional<EstimatedRobotPose> update(List<PhotonTrackedTarget> targets, double timestamp, AprilTagFieldLayout fieldTags) {
     // Skip if we only have 1 target
     // TODO change
     if (targets.size() < 1) {
@@ -57,6 +58,7 @@ public class Vision {
             inputs.constants.distCoeffs(),
             PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
             inputs.constants.robotToCamera(),
+            fieldTags,
             inputs.coprocPNPTransform);
     // // Reject if estimated pose is in the air or ground
     if (estPose.isPresent() && Math.abs(estPose.get().estimatedPose.getZ()) > 0.25) {

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -201,7 +201,7 @@ public class VisionHelper {
       Transform3d robotToCamera,
       AprilTagFieldLayout fieldTags,
       Transform3d bestTF) {
-    Optional<EstimatedRobotPose> estimatedPose;
+    final Optional<EstimatedRobotPose> estimatedPose;
     switch (strat) {
       case LOWEST_AMBIGUITY:
         estimatedPose = lowestAmbiguityStrategy(targets, timestamp, robotToCamera, fieldTags);

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -1,0 +1,459 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Quaternion;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import frc.robot.Robot;
+import frc.robot.subsystems.swerve.SwerveSubsystem;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.littletonrobotics.junction.LogTable;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.estimation.TargetModel;
+import org.photonvision.estimation.VisionEstimation;
+import org.photonvision.simulation.VisionSystemSim;
+import org.photonvision.targeting.PNPResult;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+import org.photonvision.targeting.TargetCorner;
+
+public class VisionHelper {
+
+  /***
+   * To be added
+   */
+  public static final List<TagCountDeviation> TAG_COUNT_DEVIATION_PARAMS =
+      List.of(
+          // 1 tag
+          new TagCountDeviation(
+              new UnitDeviationParams(.25, .4, .9), new UnitDeviationParams(.5, .7, 1.5)),
+
+          // 2 tags
+          new TagCountDeviation(
+              new UnitDeviationParams(.35, .1, .4), new UnitDeviationParams(.5, .7, 1.5)),
+
+          // 3+ tags
+          new TagCountDeviation(
+              new UnitDeviationParams(.25, .07, .25), new UnitDeviationParams(.15, 1, 1.5)));
+
+  public class Logging {
+    public static void logPhotonTrackedTarget(
+        PhotonTrackedTarget target, LogTable table, String name) {
+      logTransform3d(target.getBestCameraToTarget(), table, name);
+      logTransform3d(target.getAlternateCameraToTarget(), table, "Alt " + name);
+      logCorners(target, table, name);
+
+      table.put("Tags/Yaw " + name, target.getYaw());
+      table.put("Tags/Pitch " + name, target.getPitch());
+      table.put("Tags/Area " + name, target.getArea());
+      table.put("Tags/Skew " + name, target.getSkew());
+      table.put("Tags/Fiducial ID " + name, target.getFiducialId());
+      table.put("Tags/Pose Ambiguity " + name, target.getPoseAmbiguity());
+    }
+
+    public static void logCorners(PhotonTrackedTarget target, LogTable table, String name) {
+      double[] detectedCornersX = new double[4];
+      double[] detectedCornersY = new double[4];
+      double[] minAreaRectCornersX = new double[4];
+      double[] minAreaRectCornersY = new double[4];
+
+      for (int i = 0; i < 4; i++) {
+        detectedCornersX[i] = target.getDetectedCorners().get(i).x;
+        detectedCornersY[i] = target.getDetectedCorners().get(i).y;
+        minAreaRectCornersX[i] = target.getMinAreaRectCorners().get(i).x;
+        minAreaRectCornersY[i] = target.getMinAreaRectCorners().get(i).y;
+      }
+      table.put("Tags/Detected Corners X " + name, detectedCornersX);
+      table.put("Tags/Detected Corners Y " + name, detectedCornersY);
+      table.put("Tags/Min Area Rect Corners X " + name, minAreaRectCornersX);
+      table.put("Tags/Min Area Rect Corners Y " + name, minAreaRectCornersY);
+    }
+
+    public static void logTransform3d(Transform3d transform3d, LogTable table, String name) {
+      double rotation[] = new double[4];
+      rotation[0] = transform3d.getRotation().getQuaternion().getW();
+      rotation[1] = transform3d.getRotation().getQuaternion().getX();
+      rotation[2] = transform3d.getRotation().getQuaternion().getY();
+      rotation[3] = transform3d.getRotation().getQuaternion().getZ();
+      table.put("Tags/Rotation " + name, rotation);
+
+      double translation[] = new double[3];
+      translation[0] = transform3d.getTranslation().getX();
+      translation[1] = transform3d.getTranslation().getY();
+      translation[2] = transform3d.getTranslation().getZ();
+      table.put("Tags/Translation " + name, translation);
+    }
+
+    public static void logVisionConstants(VisionConstants constants, LogTable table) {
+      table.put("Vision Constants/Name ", constants.cameraName());
+      table.put("Vision Constants/Transform ", constants.robotToCamera());
+      table.put("Vision Constants/Intrinsics ", constants.intrinsicsMatrix().getData());
+      table.put("Vision Constants/Distortion ", constants.distCoeffs().getData());
+    }
+
+    public static Transform3d getLoggedTransform3d(double[] translation, double[] rotation) {
+      Transform3d transform3d =
+          new Transform3d(
+              new Translation3d(translation[0], translation[1], translation[2]),
+              new Rotation3d(new Quaternion(rotation[0], rotation[1], rotation[2], rotation[3])));
+      return transform3d;
+    }
+
+    public static Transform3d getLoggedTransform3d(LogTable table, String name) {
+      double[] rotation = table.get("Tags/Rotation " + name, new double[4]);
+      double[] translation = table.get("Tags/Translation " + name, new double[3]);
+      return getLoggedTransform3d(translation, rotation);
+    }
+
+    public static PhotonTrackedTarget getLoggedPhotonTrackedTarget(LogTable table, String name) {
+      double[] translation = table.get("Tags/Translation " + name, new double[3]);
+      double[] rotation = table.get("Tags/Rotation " + name, new double[4]);
+      double[] altTranslation = table.get("Tags/Translation Alt " + name, new double[3]);
+      double[] altRotation = table.get("Tags/Rotation Alt " + name, new double[4]);
+      double[] detectedCornersX = table.get("Tags/Detected Corners X " + name, new double[4]);
+      double[] detectedCornersY = table.get("Tags/Detected Corners Y " + name, new double[4]);
+      double[] minAreaRectCornersX =
+          table.get("Tags/Min Area Rect Corners X " + name, new double[4]);
+      double[] minAreaRectCornersY =
+          table.get("Tags/Min Area Rect Corners Y " + name, new double[4]);
+      List<TargetCorner> detectedCorners = new ArrayList<>();
+      List<TargetCorner> minAreaRectCorners = new ArrayList<>();
+
+      for (int i = 0; i < 4; i++) {
+        detectedCorners.add(new TargetCorner(detectedCornersX[i], detectedCornersY[i]));
+        minAreaRectCorners.add(new TargetCorner(minAreaRectCornersX[i], minAreaRectCornersY[i]));
+      }
+      Transform3d pose = getLoggedTransform3d(translation, rotation);
+      Transform3d altPose = getLoggedTransform3d(altTranslation, altRotation);
+      return (new PhotonTrackedTarget(
+          table.get("Tags/Yaw " + name, -1),
+          table.get("Tags/Pitch " + name, -1),
+          table.get("Tags/Area " + name, -1),
+          table.get("Tags/Skew " + name, -1),
+          (int) (table.get("Tags/Fiducial ID " + name, -1)),
+          pose,
+          altPose,
+          table.get("Tags/Pose Ambiguity " + name, -1),
+          minAreaRectCorners,
+          detectedCorners));
+    }
+
+    public static VisionConstants getLoggedVisionConstants(LogTable table) {
+      return new VisionConstants(
+          table.get("Vision Constants Name ", "Default"),
+          table.get("Vision Constants Transform ", new Transform3d()),
+          new Matrix<N3, N3>(
+              Nat.N3(),
+              Nat.N3(),
+              table.get("Vision Constants Intrinsics ", Matrix.eye(Nat.N3()).getData())),
+          new Matrix<N5, N1>(
+              Nat.N5(),
+              Nat.N1(),
+              table.get("Vision Constants Distortion ", new double[] {0.0, 0.0, 0.0, 0.0, 0.0})));
+    }
+  }
+
+  /**
+   * Updates the estimated position of the robot. Returns empty if:
+   *
+   * <ul>
+   *   <li>The timestamp of the provided pipeline result is the same as in the previous call to
+   *       {@code update()}.
+   *   <li>No targets were found in the pipeline results.
+   * </ul>
+   *
+   * @param cameraResult The latest pipeline result from the camera.
+   * @param cameraMatrix Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera.
+   * @param distCoeffs Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera
+   * @param strat The selected pose solving strategy.
+   * @param robotToCamera Transform3d from the center of the robot to the camera mount position (ie,
+   *     robot ➔ camera) in the <a href=
+   *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+   *     Coordinate System</a>.
+   * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+   *     create the estimate.
+   */
+  public static Optional<EstimatedRobotPose> update(
+      PhotonPipelineResult cameraResult,
+      Matrix<N3, N3> cameraMatrix,
+      Matrix<N5, N1> distCoeffs,
+      PoseStrategy strat,
+      Transform3d robotToCamera,
+      Transform3d bestTF) {
+    Optional<EstimatedRobotPose> estimatedPose;
+    switch (strat) {
+      case LOWEST_AMBIGUITY:
+        estimatedPose = lowestAmbiguityStrategy(cameraResult, robotToCamera);
+        break;
+      case MULTI_TAG_PNP_ON_RIO:
+        estimatedPose =
+            multiTagOnRioStrategy(
+                cameraResult,
+                Optional.of(cameraMatrix),
+                Optional.of(distCoeffs),
+                SwerveSubsystem.fieldTags,
+                PoseStrategy.LOWEST_AMBIGUITY,
+                robotToCamera);
+        break;
+      case MULTI_TAG_PNP_ON_COPROCESSOR:
+        estimatedPose =
+            multiTagOnCoprocStrategy(
+                cameraResult,
+                Optional.of(cameraMatrix),
+                Optional.of(distCoeffs),
+                robotToCamera,
+                PoseStrategy.LOWEST_AMBIGUITY,
+                bestTF);
+        break;
+      default:
+        DriverStation.reportError(
+            "[PhotonPoseEstimator] Unknown Position Estimation Strategy!", false);
+        return Optional.empty();
+    }
+
+    return estimatedPose;
+  }
+
+  /**
+   * Runs SolvePNP on the roborio
+   *
+   * @param result The latest pipeline result from the camera.
+   * @param cameraMatrix Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera.
+   * @param distCoeffs Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera
+   * @param robotToCamera Transform3d from the center of the robot to the camera mount position (ie,
+   *     robot ➔ camera) in the <a href=
+   *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+   *     Coordinate System</a>.
+   * @param multiTagFallbackStrategy Fallback strategy in case the rio fails. Should usually be
+   *     lowest ambiguity
+   * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+   *     create the estimate.
+   */
+  private static Optional<EstimatedRobotPose> multiTagOnRioStrategy(
+      PhotonPipelineResult result,
+      Optional<Matrix<N3, N3>> cameraMatrix,
+      Optional<Matrix<N5, N1>> distCoeffs,
+      AprilTagFieldLayout fieldTags,
+      PoseStrategy multiTagFallbackStrategy,
+      Transform3d robotToCamera) {
+    boolean hasCalibData = cameraMatrix.isPresent() && distCoeffs.isPresent();
+    // cannot run multitagPNP, use fallback strategy
+    if (!hasCalibData || result.getTargets().size() < 2) {
+      return update(
+          result,
+          cameraMatrix.get(),
+          distCoeffs.get(),
+          multiTagFallbackStrategy,
+          robotToCamera,
+          new Transform3d());
+    }
+
+    PNPResult pnpResult =
+        VisionEstimation.estimateCamPosePNP(
+            cameraMatrix.get(),
+            distCoeffs.get(),
+            result.getTargets(),
+            SwerveSubsystem.fieldTags,
+            TargetModel.kAprilTag36h11);
+    // try fallback strategy if solvePNP fails for some reason
+    if (!pnpResult.isPresent)
+      return update(
+          result,
+          cameraMatrix.get(),
+          distCoeffs.get(),
+          multiTagFallbackStrategy,
+          robotToCamera,
+          new Transform3d());
+    var best =
+        new Pose3d()
+            .plus(pnpResult.best) // field-to-camera
+            .plus(robotToCamera.inverse()); // field-to-robot
+
+    return Optional.of(
+        new EstimatedRobotPose(
+            best,
+            result.getTimestampSeconds(),
+            result.getTargets(),
+            PoseStrategy.MULTI_TAG_PNP_ON_RIO));
+  }
+
+  /**
+   * Runs SolvePNP on a coprocessor
+   *
+   * @param result The latest pipeline result from the camera.
+   * @param cameraMatrix Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera.
+   * @param distCoeffs Camera calibration data that can be used in the case of no assigned
+   *     PhotonCamera
+   * @param robotToCamera Transform3d from the center of the robot to the camera mount position (ie,
+   *     robot ➔ camera) in the <a href=
+   *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+   *     Coordinate System</a>.
+   * @param multiTagFallbackStrategy Fallback strategy in case the coproc fails. Should usually be
+   *     the rio or lowest ambiguity
+   * @return an {@link EstimatedRobotPose} with an estimated pose, timestamp, and targets used to
+   *     create the estimate.
+   */
+  private static Optional<EstimatedRobotPose> multiTagOnCoprocStrategy(
+      PhotonPipelineResult result,
+      Optional<Matrix<N3, N3>> cameraMatrix,
+      Optional<Matrix<N5, N1>> distCoeffs,
+      Transform3d robotToCamera,
+      PoseStrategy multiTagFallbackStrategy,
+      Transform3d bestTF) {
+    if (!bestTF.equals(new Transform3d())) {
+      var best_tf = bestTF;
+      var best =
+          new Pose3d()
+              .plus(best_tf) // field-to-camera
+              .relativeTo(SwerveSubsystem.fieldTags.getOrigin())
+              .plus(robotToCamera.inverse()); // field-to-robot
+      return Optional.of(
+          new EstimatedRobotPose(
+              best,
+              result.getTimestampSeconds(),
+              result.getTargets(),
+              PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR));
+    } else {
+      return update(
+          result,
+          cameraMatrix.get(),
+          distCoeffs.get(),
+          multiTagFallbackStrategy,
+          robotToCamera,
+          new Transform3d());
+    }
+  }
+
+  /**
+   * Return the estimated position of the robot with the lowest position ambiguity from a List of
+   * pipeline results.
+   *
+   * @param result pipeline result
+   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   *     estimation.
+   */
+  private static Optional<EstimatedRobotPose> lowestAmbiguityStrategy(
+      PhotonPipelineResult result, Transform3d robotToCamera) {
+    PhotonTrackedTarget lowestAmbiguityTarget = null;
+
+    double lowestAmbiguityScore = 10;
+
+    for (PhotonTrackedTarget target : result.targets) {
+      double targetPoseAmbiguity = target.getPoseAmbiguity();
+
+      if (target.getFiducialId() < 1 || target.getFiducialId() > 16) continue;
+
+      if (target.getBestCameraToTarget().getTranslation().getNorm() > 5) continue;
+
+      // Make sure the target is a Fiducial target.
+      if (targetPoseAmbiguity != -1 && targetPoseAmbiguity < lowestAmbiguityScore) {
+        lowestAmbiguityScore = targetPoseAmbiguity;
+        lowestAmbiguityTarget = target;
+      }
+    }
+
+    // Although there are confirmed to be targets, none of them may be fiducial
+    // targets.
+    if (lowestAmbiguityTarget == null) return Optional.empty();
+    int targetFiducialId = lowestAmbiguityTarget.getFiducialId();
+
+    Optional<Pose3d> targetPosition = SwerveSubsystem.fieldTags.getTagPose(targetFiducialId);
+
+    if (targetPosition.isEmpty()) {
+      DriverStation.reportError(
+          "[PhotonPoseEstimator] Tried to get pose of unknown AprilTag: " + targetFiducialId,
+          false);
+      return Optional.empty();
+    }
+    var estimatedRobotPose =
+        new EstimatedRobotPose(
+            targetPosition
+                .get()
+                .transformBy(lowestAmbiguityTarget.getBestCameraToTarget().inverse())
+                .transformBy(robotToCamera.inverse()),
+            result.getTimestampSeconds(),
+            result.getTargets(),
+            PoseStrategy.LOWEST_AMBIGUITY);
+    return Optional.of(estimatedRobotPose);
+  }
+
+  /*** 5026 - to be tuned if necessary*/
+  public static record UnitDeviationParams(
+      double distanceMultiplier, double eulerMultiplier, double minimum) {
+    private double computeUnitDeviation(double averageDistance) {
+      return Math.max(minimum, eulerMultiplier * Math.exp(averageDistance * distanceMultiplier));
+    }
+  }
+
+  /*** 5026 - to be tuned if necessary*/
+  public static record TagCountDeviation(
+      UnitDeviationParams xParams, UnitDeviationParams yParams, UnitDeviationParams thetaParams) {
+    private Matrix<N3, N1> computeDeviation(double averageDistance) {
+      return MatBuilder.fill(
+          Nat.N3(),
+          Nat.N1(),
+          xParams.computeUnitDeviation(averageDistance),
+          yParams.computeUnitDeviation(averageDistance),
+          thetaParams.computeUnitDeviation(averageDistance));
+    }
+
+    public TagCountDeviation(UnitDeviationParams xyParams, UnitDeviationParams thetaParams) {
+      this(xyParams, xyParams, thetaParams);
+    }
+  }
+
+  public static record VisionMeasurement(
+      EstimatedRobotPose estimation, Matrix<N3, N1> confidence) {}
+
+  /*** 5026 - to be tuned if necessary*/
+  public static Matrix<N3, N1> findVisionMeasurementStdDevs(EstimatedRobotPose estimation) {
+    double sumDistance = 0;
+    for (var target : estimation.targetsUsed) {
+      var t3d = target.getBestCameraToTarget();
+      sumDistance +=
+          Math.sqrt(Math.pow(t3d.getX(), 2) + Math.pow(t3d.getY(), 2) + Math.pow(t3d.getZ(), 2));
+    }
+    double avgDistance = sumDistance / estimation.targetsUsed.size();
+
+    var deviation = Vision.visionPointBlankDevs.times(avgDistance * Vision.distanceFactor);
+    if (estimation.targetsUsed.size() == 1) {
+      deviation = deviation.times(2);
+    }
+    // TAG_COUNT_DEVIATION_PARAMS
+    //     .get(
+    //         MathUtil.clamp(
+    //             estimation.targetsUsed.size() - 1, 0, TAG_COUNT_DEVIATION_PARAMS.size() - 1))
+    //     .computeDeviation(avgDistance);
+
+    return deviation;
+  }
+
+  /** A Field2d for visualizing our robot and objects on the field. */
+  public static Field2d getSimDebugField(VisionSystemSim visionSim) {
+    if (!Robot.isSimulation()) return null;
+    return visionSim.getDebugField();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -296,7 +296,7 @@ public class VisionHelper {
     for (PhotonTrackedTarget target : targets) {
       double targetPoseAmbiguity = target.getPoseAmbiguity();
 
-      if (target.getFiducialId() < 1 || target.getFiducialId() > 16) continue;
+      if (target.getFiducialId() < 1 || target.getFiducialId() > 22) continue;
 
       if (target.getBestCameraToTarget().getTranslation().getNorm() > 5) continue;
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -354,7 +354,10 @@ public class VisionHelper {
       EstimatedRobotPose estimation, Matrix<N3, N1> confidence) {}
 
   /*** 5026 - to be tuned if necessary*/
-  public static Matrix<N3, N1> findVisionMeasurementStdDevs(EstimatedRobotPose estimation) {
+  public static Matrix<N3, N1> findVisionMeasurementStdDevs(
+      EstimatedRobotPose estimation,
+      final Matrix<N3, N1> visionPointBlankDevs,
+      final double distanceFactor) {
     double sumDistance = 0;
     for (var target : estimation.targetsUsed) {
       var t3d = target.getBestCameraToTarget();
@@ -363,7 +366,7 @@ public class VisionHelper {
     }
     double avgDistance = sumDistance / estimation.targetsUsed.size();
 
-    var deviation = Vision.visionPointBlankDevs.times(avgDistance * Vision.distanceFactor);
+    var deviation = visionPointBlankDevs.times(avgDistance * distanceFactor);
     if (estimation.targetsUsed.size() == 1) {
       deviation = deviation.times(2);
     }

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -19,7 +19,6 @@ import edu.wpi.first.math.numbers.N8;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import frc.robot.Robot;
-import frc.robot.subsystems.swerve.SwerveSubsystem;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 import java.util.ArrayList;
 import java.util.List;
@@ -286,7 +285,10 @@ public class VisionHelper {
    *     estimation.
    */
   private static Optional<EstimatedRobotPose> lowestAmbiguityStrategy(
-      List<PhotonTrackedTarget> targets, double timestamp, Transform3d robotToCamera, AprilTagFieldLayout fieldTags) {
+      List<PhotonTrackedTarget> targets,
+      double timestamp,
+      Transform3d robotToCamera,
+      AprilTagFieldLayout fieldTags) {
     PhotonTrackedTarget lowestAmbiguityTarget = null;
 
     double lowestAmbiguityScore = 10;

--- a/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionHelper.java
@@ -14,7 +14,6 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.math.numbers.N5;
 import edu.wpi.first.math.numbers.N8;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
@@ -28,7 +27,6 @@ import org.littletonrobotics.junction.LogTable;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.simulation.VisionSystemSim;
-import org.photonvision.targeting.PhotonPipelineResult;
 import org.photonvision.targeting.PhotonTrackedTarget;
 import org.photonvision.targeting.TargetCorner;
 
@@ -166,7 +164,9 @@ public class VisionHelper {
           new Matrix<N8, N1>(
               Nat.N8(),
               Nat.N1(),
-              table.get("Vision Constants Distortion ", new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0})));
+              table.get(
+                  "Vision Constants Distortion ",
+                  new double[] {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0})));
     }
   }
 
@@ -193,7 +193,8 @@ public class VisionHelper {
    *     create the estimate.
    */
   public static Optional<EstimatedRobotPose> update(
-    List<PhotonTrackedTarget> targets, double timestamp,
+      List<PhotonTrackedTarget> targets,
+      double timestamp,
       Matrix<N3, N3> cameraMatrix,
       Matrix<N8, N1> distCoeffs,
       PoseStrategy strat,
@@ -242,7 +243,8 @@ public class VisionHelper {
    *     create the estimate.
    */
   private static Optional<EstimatedRobotPose> multiTagOnCoprocStrategy(
-    List<PhotonTrackedTarget> targets, double timestamp,
+      List<PhotonTrackedTarget> targets,
+      double timestamp,
       Optional<Matrix<N3, N3>> cameraMatrix,
       Optional<Matrix<N8, N1>> distCoeffs,
       Transform3d robotToCamera,
@@ -257,10 +259,7 @@ public class VisionHelper {
               .plus(robotToCamera.inverse()); // field-to-robot
       return Optional.of(
           new EstimatedRobotPose(
-              best,
-              timestamp,
-              targets,
-              PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR));
+              best, timestamp, targets, PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR));
     } else {
       return update(
           targets,

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -23,6 +23,7 @@ public interface VisionIO {
 
   public static class VisionIOInputs {
     public double timestamp = 0.0;
+    // latency could just be calculated from the timestamp, do we need it as an input or could it be an output?
     public double latency = 0.0;
     // We could use protobuf serialization for this instead of custom
     // There are som alleged performance considerations for protobuf

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -10,9 +10,11 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
@@ -22,17 +24,20 @@ public interface VisionIO {
   public static class VisionIOInputs {
     public double timestamp = 0.0;
     public double latency = 0.0;
+    // We could use protobuf serialization for this instead of custom
+    // There are som alleged performance considerations for protobuf
+    // Could be worth testing? This works for now
     public List<PhotonTrackedTarget> targets =
-        new ArrayList<>(); // TODO make protobuf work whenever that happens
-    public double numTags = 0; // TODO why isn't this just targets.size()?
+        new ArrayList<>();
+    public double numTags = 0; // Helps with deserialization
     public Transform3d coprocPNPTransform = new Transform3d();
-    public Pose3d[] targetPose3ds = new Pose3d[] {};
+    public Pose3d[] targetPose3ds = new Pose3d[0];
     public VisionConstants constants =
         new VisionConstants(
             "Default",
             new Transform3d(),
             Matrix.eye(Nat.N3()),
-            MatBuilder.fill(Nat.N5(), Nat.N1(), 0.0, 0.0, 0.0, 0.0, 0.0));
+            MatBuilder.fill(Nat.N8(), Nat.N1(), 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
   }
 
   public void updateInputs(VisionIOInputs inputs);

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -7,7 +7,6 @@ package frc.robot.subsystems.vision;
 import edu.wpi.first.math.MatBuilder;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.Nat;
-import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 import java.util.ArrayList;

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -1,0 +1,43 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.math.MatBuilder;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+/** Add your docs here. */
+public interface VisionIO {
+
+  public static class VisionIOInputs {
+    public double timestamp = 0.0;
+    public double latency = 0.0;
+    public List<PhotonTrackedTarget> targets =
+        new ArrayList<>(); // TODO make protobuf work whenever that happens
+    public double numTags = 0; // TODO why isn't this just targets.size()?
+    public Transform3d coprocPNPTransform = new Transform3d();
+    public Pose3d[] targetPose3ds = new Pose3d[] {};
+    public VisionConstants constants =
+        new VisionConstants(
+            "Default",
+            new Transform3d(),
+            Matrix.eye(Nat.N3()),
+            MatBuilder.fill(Nat.N5(), Nat.N1(), 0.0, 0.0, 0.0, 0.0, 0.0));
+  }
+
+  public void updateInputs(VisionIOInputs inputs);
+
+  public void setSimPose(Optional<EstimatedRobotPose> simEst, Vision camera, boolean newResult);
+
+  public String getName();
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -30,7 +30,6 @@ public interface VisionIO {
     public List<PhotonTrackedTarget> targets = new ArrayList<>();
     public double numTags = 0; // Helps with deserialization
     public Transform3d coprocPNPTransform = new Transform3d();
-    public Pose3d[] targetPose3ds = new Pose3d[0];
     public VisionConstants constants =
         new VisionConstants(
             "Default",

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -10,11 +10,9 @@ import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.targeting.PhotonTrackedTarget;
 
@@ -23,13 +21,13 @@ public interface VisionIO {
 
   public static class VisionIOInputs {
     public double timestamp = 0.0;
-    // latency could just be calculated from the timestamp, do we need it as an input or could it be an output?
+    // latency could just be calculated from the timestamp, do we need it as an input or could it be
+    // an output?
     public double latency = 0.0;
     // We could use protobuf serialization for this instead of custom
     // There are som alleged performance considerations for protobuf
     // Could be worth testing? This works for now
-    public List<PhotonTrackedTarget> targets =
-        new ArrayList<>();
+    public List<PhotonTrackedTarget> targets = new ArrayList<>();
     public double numTags = 0; // Helps with deserialization
     public Transform3d coprocPNPTransform = new Transform3d();
     public Pose3d[] targetPose3ds = new Pose3d[0];

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
@@ -1,0 +1,53 @@
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import frc.robot.subsystems.swerve.SwerveSubsystem;
+import org.littletonrobotics.junction.LogTable;
+import org.littletonrobotics.junction.inputs.LoggableInputs;
+
+/**
+ * AutoLog does not work with PhotonTrackedTargets as of yet which is very sad but until it does
+ * here is a manual implementation
+ */
+public class VisionIOInputsLogged extends VisionIO.VisionIOInputs
+    implements LoggableInputs, Cloneable {
+  @Override
+  public void toLog(LogTable table) {
+    table.put("Timestamp", timestamp);
+    table.put("Latency", latency);
+
+    targetPose3ds = new Pose3d[targets.size()];
+    for (int i = 0; i < targets.size(); i++) {
+      VisionHelper.Logging.logPhotonTrackedTarget(targets.get(i), table, String.valueOf(i));
+      targetPose3ds[i] = SwerveSubsystem.fieldTags.getTagPose(targets.get(i).getFiducialId()).get();
+    }
+    table.put("NumTags", targets.size());
+    table.put("Pose", coprocPNPTransform);
+    table.put("Target Pose3ds", targetPose3ds);
+    VisionHelper.Logging.logVisionConstants(constants, table);
+  }
+
+  @Override
+  public void fromLog(LogTable table) {
+    timestamp = table.get("Timestamp", timestamp);
+    latency = table.get("Latency", latency);
+    for (int i = 0; i < table.get("NumTags", numTags); i++) {
+      this.targets.add(VisionHelper.Logging.getLoggedPhotonTrackedTarget(table, String.valueOf(i)));
+    }
+    numTags = table.get("NumTags", numTags);
+    coprocPNPTransform = table.get("Pose", coprocPNPTransform);
+    targetPose3ds = table.get("Target Pose3ds", targetPose3ds);
+    constants = VisionHelper.Logging.getLoggedVisionConstants(table);
+  }
+
+  public VisionIOInputsLogged clone() {
+    VisionIOInputsLogged copy = new VisionIOInputsLogged();
+    copy.timestamp = this.timestamp;
+    copy.latency = this.latency;
+    copy.targets = this.targets;
+    copy.numTags = this.numTags;
+    copy.coprocPNPTransform = this.coprocPNPTransform;
+    copy.targetPose3ds = this.targetPose3ds;
+    return copy;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
@@ -16,14 +16,11 @@ public class VisionIOInputsLogged extends VisionIO.VisionIOInputs
     table.put("Timestamp", timestamp);
     table.put("Latency", latency);
 
-    targetPose3ds = new Pose3d[targets.size()];
     for (int i = 0; i < targets.size(); i++) {
       VisionHelper.Logging.logPhotonTrackedTarget(targets.get(i), table, String.valueOf(i));
-      targetPose3ds[i] = SwerveSubsystem.fieldTags.getTagPose(targets.get(i).getFiducialId()).get();
     }
     table.put("NumTags", targets.size());
     table.put("Pose", coprocPNPTransform);
-    table.put("Target Pose3ds", targetPose3ds);
     VisionHelper.Logging.logVisionConstants(constants, table);
   }
 
@@ -36,7 +33,6 @@ public class VisionIOInputsLogged extends VisionIO.VisionIOInputs
     }
     numTags = table.get("NumTags", numTags);
     coprocPNPTransform = table.get("Pose", coprocPNPTransform);
-    targetPose3ds = table.get("Target Pose3ds", targetPose3ds);
     constants = VisionHelper.Logging.getLoggedVisionConstants(table);
   }
 
@@ -47,7 +43,6 @@ public class VisionIOInputsLogged extends VisionIO.VisionIOInputs
     copy.targets = this.targets;
     copy.numTags = this.numTags;
     copy.coprocPNPTransform = this.coprocPNPTransform;
-    copy.targetPose3ds = this.targetPose3ds;
     return copy;
   }
 }

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOInputsLogged.java
@@ -1,7 +1,5 @@
 package frc.robot.subsystems.vision;
 
-import edu.wpi.first.math.geometry.Pose3d;
-import frc.robot.subsystems.swerve.SwerveSubsystem;
 import org.littletonrobotics.junction.LogTable;
 import org.littletonrobotics.junction.inputs.LoggableInputs;
 

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
@@ -42,14 +42,18 @@ public class VisionIOReal implements VisionIO {
 
   @Override
   public void updateInputs(VisionIOInputs inputs) {
-    var result = camera.getAllUnreadResults().get(0);
-    inputs.timestamp = result.getTimestampSeconds();
-    inputs.latency = (RobotController.getFPGATime() / 1e6) - result.getTimestampSeconds();
-    inputs.targets = result.targets;
-    inputs.numTags = result.targets.size();
-    inputs.constants = constants;
-    // TODO: make this cleaner and use an optional instead of kZero
-    inputs.coprocPNPTransform = result.getMultiTagResult().isPresent() ? result.getMultiTagResult().get().estimatedPose.best : Transform3d.kZero;
+    var results = camera.getAllUnreadResults();
+    if (results.size() > 0) {
+      var result = results.get(0);
+      inputs.timestamp = result.getTimestampSeconds();
+      inputs.latency = (RobotController.getFPGATime() / 1e6) - result.getTimestampSeconds();
+      inputs.targets = result.targets;
+      inputs.numTags = result.targets.size();
+      inputs.constants = constants;
+      // TODO: make this cleaner and use an optional instead of kZero
+      inputs.coprocPNPTransform = result.getMultiTagResult().isPresent() ? result.getMultiTagResult().get().estimatedPose.best : Transform3d.kZero;
+    }
+    // else leave stale data, which is the user's responsibility to handle.
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
@@ -1,0 +1,60 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.numbers.N5;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+import java.util.Optional;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+
+/** Add your docs here. */
+public class VisionIOReal implements VisionIO {
+  // constants
+  public String cameraName;
+  public PhotonCamera camera;
+  public Matrix<N3, N3> cameraMatrix;
+  public Matrix<N5, N1> distCoeffs;
+  private final VisionConstants constants;
+
+  /*** Transform3d from the center of the robot to the camera mount position (ie,
+   *     robot ➔ camera) in the <a href=
+   *     "https://docs.wpilib.org/en/stable/docs/software/advanced-controls/geometry/coordinate-systems.html#robot-coordinate-system">Robot
+   *     Coordinate System</a>.
+   ***/
+  public Transform3d robotToCamera;
+
+  public VisionIOReal(VisionConstants constants) {
+    cameraName = constants.cameraName();
+    camera = new PhotonCamera(cameraName);
+    robotToCamera = constants.robotToCamera();
+    cameraMatrix = constants.intrinsicsMatrix();
+    distCoeffs = constants.distCoeffs();
+    this.constants = constants;
+  }
+
+  @Override
+  public void updateInputs(VisionIOInputs inputs) {
+    var result = camera.getLatestResult();
+    inputs.timestamp = result.getTimestampSeconds();
+    inputs.latency = result.getLatencyMillis();
+    inputs.targets = result.targets;
+    inputs.numTags = result.targets.size();
+    inputs.constants = constants;
+    inputs.coprocPNPTransform = result.getMultiTagResult().estimatedPose.best;
+  }
+
+  @Override
+  public String getName() {
+    return cameraName;
+  }
+
+  @Override
+  public void setSimPose(Optional<EstimatedRobotPose> simEst, Vision camera, boolean newResult) {}
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOReal.java
@@ -51,7 +51,10 @@ public class VisionIOReal implements VisionIO {
       inputs.numTags = result.targets.size();
       inputs.constants = constants;
       // TODO: make this cleaner and use an optional instead of kZero
-      inputs.coprocPNPTransform = result.getMultiTagResult().isPresent() ? result.getMultiTagResult().get().estimatedPose.best : Transform3d.kZero;
+      inputs.coprocPNPTransform =
+          result.getMultiTagResult().isPresent()
+              ? result.getMultiTagResult().get().estimatedPose.best
+              : Transform3d.kZero;
     }
     // else leave stale data, which is the user's responsibility to handle.
   }

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -67,12 +67,16 @@ public class VisionIOSim implements VisionIO {
 
   @Override
   public void updateInputs(VisionIOInputs inputs) {
-    var result = camera.getAllUnreadResults().get(0);
+    var results = camera.getAllUnreadResults();
+    if (results.size() > 0) {
+      var result = results.get(0);
+      inputs.timestamp = result.getTimestampSeconds();
+      inputs.latency = (RobotController.getFPGATime() / 1e6) - result.getTimestampSeconds();
+      inputs.targets = result.targets; // TODO aaaaaaa
+      inputs.constants = constants;
+    }
+    // else leave stale data
     sim.update(pose.get().toPose2d());
-    inputs.timestamp = result.getTimestampSeconds();
-    inputs.latency = (RobotController.getFPGATime() / 1e6) - result.getTimestampSeconds();
-    inputs.targets = result.targets; // TODO aaaaaaa
-    inputs.constants = constants;
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -4,8 +4,8 @@
 
 package frc.robot.subsystems.vision;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.wpilibj.RobotController;
@@ -25,7 +25,7 @@ public class VisionIOSim implements VisionIO {
   private final PhotonCameraSim simCamera;
   private final VisionConstants constants;
 
-  public static Supplier<Pose3d> pose;  
+  public static Supplier<Pose3d> pose;
 
   public VisionIOSim(VisionConstants constants) {
     this.sim = new VisionSystemSim(constants.cameraName());

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -1,0 +1,79 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems.vision;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.geometry.Pose3d;
+import frc.robot.subsystems.vision.Vision.VisionConstants;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.simulation.PhotonCameraSim;
+import org.photonvision.simulation.SimCameraProperties;
+import org.photonvision.simulation.VisionSystemSim;
+
+/** Add your docs here. */
+public class VisionIOSim implements VisionIO {
+  private final VisionSystemSim sim;
+  private final PhotonCamera camera;
+  private final PhotonCameraSim simCamera;
+  private final VisionConstants constants;
+  public static Supplier<Pose3d> pose;
+
+  public VisionIOSim(VisionConstants constants) {
+    this.sim = new VisionSystemSim(constants.cameraName());
+    var cameraProp = new SimCameraProperties();
+    // TODO Fix these constants
+    cameraProp.setCalibration(1080, 960, constants.intrinsicsMatrix(), constants.distCoeffs());
+    cameraProp.setCalibError(0.0, 0.0);
+    cameraProp.setFPS(50.0);
+    cameraProp.setAvgLatencyMs(30.0);
+    cameraProp.setLatencyStdDevMs(5.0);
+    this.camera = new PhotonCamera(constants.cameraName());
+    this.simCamera = new PhotonCameraSim(camera, cameraProp);
+    simCamera.enableDrawWireframe(true);
+    simCamera.setMaxSightRange(7.0);
+    this.constants = constants;
+    sim.addCamera(simCamera, constants.robotToCamera());
+
+    try {
+      var field = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+      field.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
+      sim.addAprilTags(field);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void setSimPose(Optional<EstimatedRobotPose> simEst, Vision camera, boolean newResult) {
+    simEst.ifPresentOrElse(
+        est ->
+            VisionHelper.getSimDebugField(sim)
+                .getObject("VisionEstimation")
+                .setPose(est.estimatedPose.toPose2d()),
+        () -> {
+          if (newResult)
+            VisionHelper.getSimDebugField(sim).getObject("VisionEstimation").setPoses();
+        });
+  }
+
+  @Override
+  public void updateInputs(VisionIOInputs inputs) {
+    var result = camera.getLatestResult();
+    sim.update(pose.get().toPose2d());
+    inputs.timestamp = result.getTimestampSeconds();
+    inputs.latency = result.getLatencyMillis();
+    inputs.targets = result.targets; // TODO aaaaaaa
+    inputs.constants = constants;
+  }
+
+  @Override
+  public String getName() {
+    return constants.cameraName();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -5,8 +5,10 @@
 package frc.robot.subsystems.vision;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.wpilibj.RobotController;
 import frc.robot.subsystems.vision.Vision.VisionConstants;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -22,7 +24,8 @@ public class VisionIOSim implements VisionIO {
   private final PhotonCamera camera;
   private final PhotonCameraSim simCamera;
   private final VisionConstants constants;
-  public static Supplier<Pose3d> pose;
+
+  public static Supplier<Pose3d> pose;  
 
   public VisionIOSim(VisionConstants constants) {
     this.sim = new VisionSystemSim(constants.cameraName());
@@ -41,7 +44,7 @@ public class VisionIOSim implements VisionIO {
     sim.addCamera(simCamera, constants.robotToCamera());
 
     try {
-      var field = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
+      var field = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
       field.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
       sim.addAprilTags(field);
     } catch (Exception e) {
@@ -64,10 +67,10 @@ public class VisionIOSim implements VisionIO {
 
   @Override
   public void updateInputs(VisionIOInputs inputs) {
-    var result = camera.getLatestResult();
+    var result = camera.getAllUnreadResults().get(0);
     sim.update(pose.get().toPose2d());
     inputs.timestamp = result.getTimestampSeconds();
-    inputs.latency = result.getLatencyMillis();
+    inputs.latency = (RobotController.getFPGATime() / 1e6) - result.getTimestampSeconds();
     inputs.targets = result.targets; // TODO aaaaaaa
     inputs.constants = constants;
   }

--- a/src/main/java/frc/robot/utils/CommandXboxControllerSubsystem.java
+++ b/src/main/java/frc/robot/utils/CommandXboxControllerSubsystem.java
@@ -1,0 +1,34 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import edu.wpi.first.wpilibj.GenericHID.RumbleType;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import java.util.function.DoubleSupplier;
+
+/** A CommandXboxController that implements Subsystem to allow the rumble to be mutexed. */
+public class CommandXboxControllerSubsystem extends CommandXboxController implements Subsystem {
+
+  public CommandXboxControllerSubsystem(int port) {
+    super(port);
+  }
+
+  /** Rumble the controller at the specified power. */
+  public Command rumbleCmd(DoubleSupplier left, DoubleSupplier right) {
+    return this.run(
+            () -> {
+              super.getHID().setRumble(RumbleType.kLeftRumble, left.getAsDouble());
+              super.getHID().setRumble(RumbleType.kRightRumble, right.getAsDouble());
+            })
+        .finallyDo(() -> super.getHID().setRumble(RumbleType.kBothRumble, 0.0));
+  }
+
+  /** Rumble the controller at the specified power. */
+  public Command rumbleCmd(double left, double right) {
+    return rumbleCmd(() -> left, () -> right);
+  }
+}

--- a/src/main/java/frc/robot/utils/Tracer.java
+++ b/src/main/java/frc/robot/utils/Tracer.java
@@ -1,0 +1,196 @@
+package frc.robot.utils;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.function.Supplier;
+import org.littletonrobotics.junction.Logger;
+
+/**
+ * Thanks to oh-yes-0-fps and <a
+ * href="https://github.com/McQuaidRobotics/2024_Crescendo/blob/main/src/main/java/com/igknighters/util/Tracer.java">FRC
+ * 3173!</a>
+ *
+ * <p>A newer version of this class is being merged into WPILib for 2025, and should supersede this
+ * file once merged. The WPILib version may not support logging to akit the way we want, revisit
+ * then (might need to manually connect nt publishing to log)
+ *
+ * <p>A Utility class for tracing code execution time. Will put info to Advantagekit under "Tracer".
+ *
+ * <pre><code>
+ *
+ * @Override
+ * public void loopFunc() {
+ *    Tracer.trace("LoopFunc", super::loopFunc);
+ * }
+ *
+ * <p>
+ *
+ * @Override
+ * public void robotPeriodic() {
+ *     Tracer.trace("CommandScheduler", scheduler::run);
+ * }
+ *
+ * </code></pre>
+ */
+public class Tracer {
+  private static final class TraceStartData {
+    private double startTime = 0.0;
+    private double startGCTotalTime = 0.0;
+
+    private void set(double startTime, double startGCTotalTime) {
+      this.startTime = startTime;
+      this.startGCTotalTime = startGCTotalTime;
+    }
+  }
+
+  /**
+   * All of the tracers persistent state in a single object to be stored in a {@link ThreadLocal}.
+   */
+  private static final class TracerState {
+
+    // the stack of traces, every startTrace will add to this stack
+    // and every endTrace will remove from this stack
+    private final ArrayList<String> traceStack = new ArrayList<>();
+    // ideally we only need `traceStack` but in the interest of memory optimization
+    // and string concatenation speed we store the history of the stack to reuse the stack names
+    private final ArrayList<String> traceStackHistory = new ArrayList<>();
+    // the time of each trace, the key is the trace name, modified every endTrace
+    private final HashMap<String, Double> traceTimes = new HashMap<>();
+    // the start time of each trace and the gc time at the start of the trace,
+    // the key is the trace name, modified every startTrace and endTrace.
+    private final HashMap<String, TraceStartData> traceStartTimes = new HashMap<>();
+    private final ArrayList<String> entryArray = new ArrayList<>();
+
+    // the garbage collector beans
+    private final ArrayList<GarbageCollectorMXBean> gcs =
+        new ArrayList<>(ManagementFactory.getGarbageCollectorMXBeans());
+    private double gcTimeThisCycle = 0.0;
+
+    private TracerState(String threadName) {}
+
+    private String appendTraceStack(String trace) {
+      traceStack.add(trace);
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < traceStack.size(); i++) {
+        sb.append(traceStack.get(i));
+        if (i < traceStack.size() - 1) {
+          sb.append("/");
+        }
+      }
+      String str = sb.toString();
+      traceStackHistory.add(str);
+      return str;
+    }
+
+    private String popTraceStack() {
+      traceStack.remove(traceStack.size() - 1);
+      return traceStackHistory.remove(traceStackHistory.size() - 1);
+    }
+
+    private double totalGCTime() {
+      double gcTime = 0;
+      for (GarbageCollectorMXBean gc : gcs) {
+        gcTime += gc.getCollectionTime();
+      }
+      return gcTime;
+    }
+
+    private void endCycle() {
+      // update times for all already existing entries
+      for (var entry : entryArray) {
+        // if the entry isn't found, time will null-cast to 0.0
+        Double time = traceTimes.remove(entry);
+        if (time == null) time = 0.0;
+        Logger.recordOutput("Tracer/" + entry, time);
+      }
+      // log all new entries
+      for (var traceTime : traceTimes.entrySet()) {
+        Logger.recordOutput("Tracer/" + traceTime.getKey(), traceTime.getValue());
+        entryArray.add(traceTime.getKey());
+      }
+
+      // log gc time
+      if (gcs.size() > 0) Logger.recordOutput("Tracer/GCTime", gcTimeThisCycle);
+      gcTimeThisCycle = 0.0;
+
+      // clean up state
+      traceTimes.clear();
+      traceStackHistory.clear();
+    }
+  }
+
+  private static final ThreadLocal<TracerState> threadLocalState =
+      ThreadLocal.withInitial(
+          () -> {
+            return new TracerState(Thread.currentThread().getName());
+          });
+
+  public static void disableGcLoggingForCurrentThread() {
+    TracerState state = threadLocalState.get();
+    state.gcs.clear();
+  }
+
+  private static void startTrace(final String name, final TracerState state) {
+    String stack = state.appendTraceStack(name);
+    TraceStartData data = state.traceStartTimes.get(stack);
+    if (data == null) {
+      data = new TraceStartData();
+      state.traceStartTimes.put(stack, data);
+    }
+    data.set(Logger.getRealTimestamp() / 1000.0, state.totalGCTime());
+  }
+
+  private static void endTrace(final TracerState state) {
+    try {
+      String stack = state.popTraceStack();
+      var startData = state.traceStartTimes.get(stack);
+      double gcTimeSinceStart = state.totalGCTime() - startData.startGCTotalTime;
+      state.gcTimeThisCycle += gcTimeSinceStart;
+      state.traceTimes.put(
+          stack, Logger.getRealTimestamp() / 1000.0 - startData.startTime - gcTimeSinceStart);
+      if (state.traceStack.size() == 0) {
+        state.endCycle();
+      }
+    } catch (Exception e) {
+      DriverStation.reportError(
+          "[Tracer] An end trace was called with no opening trace " + e, true);
+    }
+  }
+
+  /**
+   * Traces a function.
+   *
+   * @param name the name of the trace, should be unique to the function.
+   * @param runnable the function to trace.
+   * @apiNote If you want to return a value then use {@link Tracer#trace(String, Supplier)}.
+   */
+  public static void trace(String name, Runnable runnable) {
+    final TracerState state = threadLocalState.get();
+    try {
+      startTrace(name, state);
+      runnable.run();
+    } finally {
+      endTrace(state);
+    }
+  }
+
+  /**
+   * Traces a function.
+   *
+   * @param name the name of the trace, should be unique to the function.
+   * @param supplier the function to trace.
+   */
+  public static <T> T trace(String name, Supplier<T> supplier) {
+    final TracerState state = threadLocalState.get();
+    try {
+      startTrace(name, state);
+      T ret = supplier.get();
+      return ret;
+    } finally {
+      endTrace(state);
+    }
+  }
+}

--- a/vendordeps/ChoreoLib2025Beta.json
+++ b/vendordeps/ChoreoLib2025Beta.json
@@ -1,7 +1,7 @@
 {
   "fileName": "ChoreoLib2025Beta.json",
   "name": "ChoreoLib",
-  "version": "2025.0.0-beta-7",
+  "version": "2025.0.0-beta-8",
   "uuid": "b5e23f0a-dac9-4ad2-8dd6-02767c520aca",
   "frcYear": "2025",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "choreo",
       "artifactId": "ChoreoLib-java",
-      "version": "2025.0.0-beta-7"
+      "version": "2025.0.0-beta-8"
     },
     {
       "groupId": "com.google.code.gson",
@@ -26,7 +26,7 @@
     {
       "groupId": "choreo",
       "artifactId": "ChoreoLib-cpp",
-      "version": "2025.0.0-beta-7",
+      "version": "2025.0.0-beta-8",
       "libName": "ChoreoLib",
       "headerClassifier": "headers",
       "sharedLibrary": false,

--- a/vendordeps/Phoenix6-frc2025-beta-latest.json
+++ b/vendordeps/Phoenix6-frc2025-beta-latest.json
@@ -1,7 +1,7 @@
 {
-  "fileName": "Phoenix6-25.0.0-beta-3.json",
+  "fileName": "Phoenix6-frc2025-beta-latest.json",
   "name": "CTRE-Phoenix (v6)",
-  "version": "25.0.0-beta-3",
+  "version": "25.0.0-beta-4",
   "frcYear": "2025",
   "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
   "mavenUrls": [
@@ -19,14 +19,14 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-java",
-      "version": "25.0.0-beta-3"
+      "version": "25.0.0-beta-4"
     }
   ],
   "jniDependencies": [
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "api-cpp",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -40,7 +40,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -54,7 +54,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "api-cpp-sim",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -68,7 +68,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -82,7 +82,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -96,7 +96,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -110,7 +110,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -124,7 +124,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -138,7 +138,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -152,7 +152,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -166,7 +166,21 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
+      "isJar": false,
+      "skipInvalidPlatforms": true,
+      "validPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANrange",
+      "version": "25.0.0-beta-4",
       "isJar": false,
       "skipInvalidPlatforms": true,
       "validPlatforms": [
@@ -182,7 +196,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "wpiapi-cpp",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_Phoenix6_WPI",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -198,7 +212,7 @@
     {
       "groupId": "com.ctre.phoenix6",
       "artifactId": "tools",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_PhoenixTools",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -214,7 +228,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "wpiapi-cpp-sim",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_Phoenix6_WPISim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -230,7 +244,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "tools-sim",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_PhoenixTools_Sim",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -246,7 +260,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simTalonSRX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimTalonSRX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -262,7 +276,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simVictorSPX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimVictorSPX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -278,7 +292,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simPigeonIMU",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimPigeonIMU",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -294,7 +308,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simCANCoder",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimCANCoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -310,7 +324,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProTalonFX",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimProTalonFX",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -326,7 +340,7 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProCANcoder",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimProCANcoder",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -342,8 +356,24 @@
     {
       "groupId": "com.ctre.phoenix6.sim",
       "artifactId": "simProPigeon2",
-      "version": "25.0.0-beta-3",
+      "version": "25.0.0-beta-4",
       "libName": "CTRE_SimProPigeon2",
+      "headerClassifier": "headers",
+      "sharedLibrary": true,
+      "skipInvalidPlatforms": true,
+      "binaryPlatforms": [
+        "windowsx86-64",
+        "linuxx86-64",
+        "linuxarm64",
+        "osxuniversal"
+      ],
+      "simMode": "swsim"
+    },
+    {
+      "groupId": "com.ctre.phoenix6.sim",
+      "artifactId": "simProCANrange",
+      "version": "25.0.0-beta-4",
+      "libName": "CTRE_SimProCANrange",
       "headerClassifier": "headers",
       "sharedLibrary": true,
       "skipInvalidPlatforms": true,

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2025.0.0-beta-5",
+  "version": "v2025.0.0-beta-6",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "frcYear": "2025",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2025.0.0-beta-5",
+      "version": "v2025.0.0-beta-6",
       "skipInvalidPlatforms": true,
       "isJar": false,
       "validPlatforms": [
@@ -28,7 +28,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-cpp",
-      "version": "v2025.0.0-beta-5",
+      "version": "v2025.0.0-beta-6",
       "libName": "photonlib",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -43,7 +43,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2025.0.0-beta-5",
+      "version": "v2025.0.0-beta-6",
       "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -60,12 +60,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-java",
-      "version": "v2025.0.0-beta-5"
+      "version": "v2025.0.0-beta-6"
     },
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-java",
-      "version": "v2025.0.0-beta-5"
+      "version": "v2025.0.0-beta-6"
     }
   ]
 }


### PR DESCRIPTION
all swerve constants are abstracted to be getters on `SwerveConstants`, which is subclassed for each robot as selected via `ROBOT_HARDWARE` in `Robot.java`. There are still a few spots with non-updated deprecated features in use, but nothing that will be removed for 2025. 